### PR TITLE
fix: dodge YouTube datacenter-IP bot-wall (player_client swap + deno)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,33 @@
 name: Deploy
 
+# Chained off CI so a merge that breaks tests or typecheck cannot reach
+# the VPS. `workflow_dispatch` stays available for manual replays but is
+# restricted to `main` so it can't be used to push feature-branch code
+# to prod.
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: vps-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
+    if: >-
+      (github.event_name == 'workflow_dispatch' &&
+       github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Deploy to server
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,11 @@ jobs:
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
+    # Default GITHUB_TOKEN on repos created after Feb 2023 is read-only.
+    # `issues: write` is required for the failure-alert step below.
+    permissions:
+      contents: read
+      issues: write
     env:
       # Pin the VPS to the exact commit CI validated. Without this, the
       # VPS-side `git pull` could fetch a newer commit that hasn't been
@@ -56,12 +61,16 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const sha = process.env.DEPLOY_SHA;
+            // Fall back through every source so the alert can't crash
+            // on a missing env — the alert's job is to surface failure,
+            // not become one.
+            const sha = process.env.DEPLOY_SHA || context.sha || "unknown";
+            const shortSha = sha === "unknown" ? "unknown" : sha.slice(0, 7);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Deploy failed for ${sha.slice(0, 7)}`,
+              title: `Deploy failed for ${shortSha}`,
               body: [
                 `Deploy workflow failed.`,
                 ``,

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,10 +24,16 @@ jobs:
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
+    env:
+      # Pin the VPS to the exact commit CI validated. Without this, the
+      # VPS-side `git pull` could fetch a newer commit that hasn't been
+      # through CI when two merges land close together.
+      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ env.DEPLOY_SHA }}
 
       - name: Deploy to server
         uses: appleboy/ssh-action@v1
@@ -35,7 +41,34 @@ jobs:
           host: ${{ secrets.SERVER_HOST }}
           username: root
           key: ${{ secrets.SERVER_SSH_KEY }}
+          envs: DEPLOY_SHA
           script: |
+            set -euo pipefail
             cd /opt/youtube-ai-service
-            git pull --quiet
+            git fetch --quiet origin "$DEPLOY_SHA"
+            git checkout --quiet --detach "$DEPLOY_SHA"
             ./scripts/deploy.sh
+
+      # `workflow_run`-triggered failures don't surface on the PR/commit
+      # status UI. Open an issue so a busted deploy can't sit unnoticed.
+      - name: Open issue on deploy failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = process.env.DEPLOY_SHA;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Deploy failed for ${sha.slice(0, 7)}`,
+              body: [
+                `Deploy workflow failed.`,
+                ``,
+                `- Commit: ${sha}`,
+                `- Run: ${runUrl}`,
+                ``,
+                `VPS state may be on the previous commit; investigate before merging further changes.`,
+              ].join("\n"),
+              labels: ["deploy-failure"],
+            });

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ RUN npx tsc
 
 FROM node:22-slim
 
+# Enable pipefail for every RUN so a failing pipe component (e.g. a 503
+# from an install.sh download) aborts the build instead of silently
+# feeding a truncated script into the next stage.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv ffmpeg curl unzip ca-certificates \
     && python3 -m venv /opt/venv \
@@ -17,9 +22,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install deno — yt-dlp warns "No supported JavaScript runtime could be
 # found" without it, and some newer YouTube player clients need JS to
-# solve nonce/signature challenges during extraction.
-RUN curl -fsSL https://deno.land/install.sh | sh -s -- --yes \
-    && mv /root/.deno/bin/deno /usr/local/bin/deno
+# solve nonce/signature challenges during extraction. Version pinned so
+# a breaking deno release can't ship to prod on the next image rebuild.
+ARG DENO_VERSION=v2.1.4
+RUN curl -fsSL https://deno.land/install.sh | sh -s -- --yes ${DENO_VERSION} \
+    && mv /root/.deno/bin/deno /usr/local/bin/deno \
+    && deno --version
 
 ENV PATH="/opt/venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,16 @@ RUN npx tsc
 FROM node:22-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-venv ffmpeg \
+    python3 python3-pip python3-venv ffmpeg curl unzip ca-certificates \
     && python3 -m venv /opt/venv \
     && /opt/venv/bin/pip install --no-cache-dir faster-whisper yt-dlp \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install deno — yt-dlp warns "No supported JavaScript runtime could be
+# found" without it, and some newer YouTube player clients need JS to
+# solve nonce/signature challenges during extraction.
+RUN curl -fsSL https://deno.land/install.sh | sh -s -- --yes \
+    && mv /root/.deno/bin/deno /usr/local/bin/deno
 
 ENV PATH="/opt/venv/bin:$PATH"
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 # Deploy or update youtube-ai-service on VPS.
-# Pulls latest code, rebuilds image, restarts container.
+# Rebuilds the image and restarts the container.
+#
+# Wrapped in flock so two concurrent deploys (e.g. workflow_dispatch racing
+# a workflow_run trigger) can't interleave docker-compose state on the host.
+# GHA's `concurrency` group serializes GHA jobs but not VPS-side processes.
 
 set -euo pipefail
+
+LOCK_FILE="/var/lock/youtube-ai-deploy.lock"
+
+exec {LOCK_FD}>"$LOCK_FILE"
+if ! flock --exclusive --nonblock "$LOCK_FD"; then
+  echo "Another deploy is already in progress (lock: $LOCK_FILE); aborting."
+  exit 1
+fi
 
 cd "$(dirname "$0")/.."
 

--- a/src/lib/__tests__/ytdlp.test.ts
+++ b/src/lib/__tests__/ytdlp.test.ts
@@ -15,15 +15,21 @@ describe("buildYtdlpArgs", () => {
     expect(args).toContain("https://www.youtube.com/watch?v=test123");
   });
 
-  it("passes alternate player_client list so datacenter IPs avoid the default web client's bot-check", () => {
+  it("never tries the default `web` client first (it's the one hit by the datacenter-IP bot-wall)", () => {
     const args = buildYtdlpArgs("https://youtu.be/x", "/tmp/x.mp3");
     const extractorArgsIdx = args.indexOf("--extractor-args");
     expect(extractorArgsIdx).toBeGreaterThan(-1);
     const value = args[extractorArgsIdx + 1];
     expect(value).toMatch(/^youtube:player_client=/);
-    // Must include at least one non-web client so a web-specific block
-    // doesn't take the whole path down.
-    expect(value).toMatch(/mweb|android|safari|ios/);
+
+    const clients = value
+      .replace(/^youtube:player_client=/, "")
+      .split(",")
+      .map((c) => c.trim());
+    expect(clients.length).toBeGreaterThan(0);
+    // Plain "web" in the first slot would silently re-introduce the
+    // blocked client. Variants like web_safari are fine.
+    expect(clients[0]).not.toBe("web");
   });
 
   it("sets a browser User-Agent matching the player_client profile", () => {

--- a/src/lib/__tests__/ytdlp.test.ts
+++ b/src/lib/__tests__/ytdlp.test.ts
@@ -14,4 +14,22 @@ describe("buildYtdlpArgs", () => {
     expect(args).toContain("/tmp/audio.mp3");
     expect(args).toContain("https://www.youtube.com/watch?v=test123");
   });
+
+  it("passes alternate player_client list so datacenter IPs avoid the default web client's bot-check", () => {
+    const args = buildYtdlpArgs("https://youtu.be/x", "/tmp/x.mp3");
+    const extractorArgsIdx = args.indexOf("--extractor-args");
+    expect(extractorArgsIdx).toBeGreaterThan(-1);
+    const value = args[extractorArgsIdx + 1];
+    expect(value).toMatch(/^youtube:player_client=/);
+    // Must include at least one non-web client so a web-specific block
+    // doesn't take the whole path down.
+    expect(value).toMatch(/mweb|android|safari|ios/);
+  });
+
+  it("sets a browser User-Agent matching the player_client profile", () => {
+    const args = buildYtdlpArgs("https://youtu.be/x", "/tmp/x.mp3");
+    const uaIdx = args.indexOf("--user-agent");
+    expect(uaIdx).toBeGreaterThan(-1);
+    expect(args[uaIdx + 1]).toMatch(/Mozilla\//);
+  });
 });

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -4,6 +4,17 @@ import { unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 
+// Datacenter IPs frequently hit YouTube's "Sign in to confirm you're not a
+// bot" wall when yt-dlp uses the default `web` player client. Cycling
+// through alternate clients (mweb / web_safari / android_vr) unblocks most
+// requests at zero extra cost. If YouTube escalates and these also fail,
+// the next lever is a cookies.txt from a logged-in throwaway account.
+const YOUTUBE_PLAYER_CLIENTS = "web_safari,mweb,android_vr";
+
+// Pair the client list with a browser UA so the request profile matches.
+const SAFARI_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
 export function buildYtdlpArgs(url: string, outputPath: string): string[] {
   return [
     "--extract-audio",
@@ -12,6 +23,10 @@ export function buildYtdlpArgs(url: string, outputPath: string): string[] {
     "--audio-quality",
     "0",
     "--no-playlist",
+    "--extractor-args",
+    `youtube:player_client=${YOUTUBE_PLAYER_CLIENTS}`,
+    "--user-agent",
+    SAFARI_USER_AGENT,
     "-o",
     outputPath,
     url,

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -1,6 +1,6 @@
 import { execFile } from "child_process";
 import { randomUUID } from "crypto";
-import { unlink } from "fs/promises";
+import { stat, unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -40,17 +40,37 @@ export function buildYtdlpArgs(url: string, outputPath: string): string[] {
 export async function downloadAudio(youtubeUrl: string): Promise<string> {
   const outputPath = join(tmpdir(), `ytai-${randomUUID()}.mp3`);
 
-  return new Promise((resolve, reject) => {
+  const stderr = await new Promise<string>((resolve, reject) => {
     const args = buildYtdlpArgs(youtubeUrl, outputPath);
-
-    execFile("yt-dlp", args, { timeout: 300_000 }, (error, _stdout, stderr) => {
+    execFile("yt-dlp", args, { timeout: 300_000 }, (error, _stdout, err) => {
       if (error) {
-        reject(new Error(`yt-dlp failed: ${stderr || error.message}`));
+        reject(new Error(`yt-dlp failed: ${err || error.message}`));
         return;
       }
-      resolve(outputPath);
+      resolve(err);
     });
   });
+
+  // yt-dlp can exit 0 with a missing or empty file when player-client
+  // cascades partially succeed (metadata extracted, stream URL returns
+  // 0 bytes). Without this check Whisper gets a dead file and throws an
+  // opaque decoder error far from the real cause.
+  let size: number;
+  try {
+    size = (await stat(outputPath)).size;
+  } catch {
+    throw new Error(
+      `yt-dlp exited 0 but produced no file at ${outputPath} (stderr: ${stderr.slice(0, 500)})`
+    );
+  }
+  if (size === 0) {
+    await unlink(outputPath).catch(() => {});
+    throw new Error(
+      `yt-dlp exited 0 but produced a 0-byte file (stderr: ${stderr.slice(0, 500)})`
+    );
+  }
+
+  return outputPath;
 }
 
 /**


### PR DESCRIPTION
## Summary
Vercel runtime logs for today's `/api/summarize/stream` requests show the VPS returning 500 from `/transcribe`. VPS container log (01:22 UTC):

\`\`\`
ERROR: [youtube] YuoKJ36a2bo: Sign in to confirm you're not a bot.
WARNING: [youtube] No supported JavaScript runtime could be found.
\`\`\`

YouTube fingerprints Hetzner's IP range + the default \`web\` yt-dlp player client and serves a bot-wall. Missing JS runtime in the container makes the fallback paths even thinner.

## Changes
- \`src/lib/ytdlp.ts\` — add \`--extractor-args youtube:player_client=web_safari,mweb,android_vr\` + a matching Safari UA.
- \`Dockerfile\` — install deno (yt-dlp uses it for nonce/signature challenges).
- \`src/lib/__tests__/ytdlp.test.ts\` — cover the new args.

## Test plan
- [x] Local: \`npx tsc --noEmit\`, \`npx vitest run\` (4 passed)
- [ ] CI: expect green
- [ ] After merge + deploy: submit a captionless YouTube video in prod, confirm progress advances past 30% → 100% and no \`[summarize/stream] vps fail\` in Vercel runtime logs

## Out of scope
- Cookies from a logged-in throwaway account — next lever if YouTube escalates past this workaround.

## Deployment note
\`.github/workflows/deploy.yml\` triggers on push to \`main\` but is **not** gated on CI success. Same foot-gun we just fixed on \`youtubeai_chat_frontend\`'s \`db-migrate.yml\`. Worth a follow-up PR to chain off CI via \`workflow_run\` (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)