### PR TITLE
fix: use whisper-ctranslate2 CLI (faster-whisper pkg ships no binary)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,23 @@ ARG BGUTIL_POT_VERSION=1.3.1
 # (`faster-whisper` the pip package ships no binary — just the Python
 # library — which is why a naive `pip install faster-whisper` leaves a
 # latent ENOENT at transcribe time). whisper-ctranslate2 depends on
-# faster-whisper so the underlying runtime is identical.
+# faster-whisper so the underlying runtime is identical. Version pinned
+# so the default output-filename convention (`<stem>.txt`) — which
+# `whisper.ts` reads by constructing the same path — can't shift under us
+# on a rebuild and re-break transcription after a successful image build.
+ARG WHISPER_CT2_VERSION=0.5.7
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv ffmpeg curl unzip ca-certificates \
     && python3 -m venv /opt/venv \
     && /opt/venv/bin/pip install --no-cache-dir \
-        whisper-ctranslate2 \
+        "whisper-ctranslate2==${WHISPER_CT2_VERSION}" \
         yt-dlp \
         "bgutil-ytdlp-pot-provider==${BGUTIL_POT_VERSION}" \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    # Smoke-test the binary at build time so a future Dockerfile edit that
+    # breaks the venv PATH or mangles the pip install fails the build
+    # instead of shipping an image that ENOENTs at first user request.
+    && /opt/venv/bin/whisper-ctranslate2 --version >/dev/null
 
 # `bgutil-ytdlp-pot-provider` is a yt-dlp plugin that fetches Proof-of-Origin
 # tokens from the `pot-provider` sidecar container (see docker-compose.yml).

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,16 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # plugin returns no PO Token and yt-dlp falls back to no-PO-Token mode,
 # which YouTube rejects for player responses.
 ARG BGUTIL_POT_VERSION=1.3.1
+# `whisper-ctranslate2` is the CLI wrapper that `src/lib/whisper.ts` invokes
+# (`faster-whisper` the pip package ships no binary — just the Python
+# library — which is why a naive `pip install faster-whisper` leaves a
+# latent ENOENT at transcribe time). whisper-ctranslate2 depends on
+# faster-whisper so the underlying runtime is identical.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv ffmpeg curl unzip ca-certificates \
     && python3 -m venv /opt/venv \
     && /opt/venv/bin/pip install --no-cache-dir \
-        faster-whisper \
+        whisper-ctranslate2 \
         yt-dlp \
         "bgutil-ytdlp-pot-provider==${BGUTIL_POT_VERSION}" \
     && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/scripts/post-deploy-smoke.sh
+++ b/scripts/post-deploy-smoke.sh
@@ -32,6 +32,19 @@ if [[ "$container_ip" == "$vps_ip" ]]; then
 fi
 echo "[smoke] OK: VPS egress=$vps_ip, container egress=$container_ip (residential)"
 
+echo "[smoke] whisper-ctranslate2: verifying the CLI binary is on PATH inside the app container"
+# The original transcribe outage (PR #6) was a latent ENOENT on a missing
+# CLI — pip installed `faster-whisper` the library, but no `faster-whisper`
+# binary existed. Verifying `--version` from a shell that matches the one
+# `execFile` uses catches venv PATH drift, package renames, and image
+# misconfigurations before any user hits them.
+if ! docker exec youtube-ai-service whisper-ctranslate2 --version >/dev/null 2>&1; then
+  echo "[smoke] FAIL: whisper-ctranslate2 not reachable from app container"
+  docker exec youtube-ai-service whisper-ctranslate2 --version 2>&1 | tail -5 || true
+  exit 1
+fi
+echo "[smoke] OK: whisper-ctranslate2 reachable"
+
 echo "[smoke] pot-provider: verifying HTTP listener is reachable from the app container"
 if ! docker exec youtube-ai-service node -e "require('http').get('http://127.0.0.1:4416/ping', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"; then
   echo "[smoke] FAIL: pot-provider /ping not reachable from app container"

--- a/src/lib/__tests__/whisper.test.ts
+++ b/src/lib/__tests__/whisper.test.ts
@@ -11,10 +11,29 @@ describe("buildWhisperArgs", () => {
     expect(args).toContain("txt");
   });
 
-  it("targets the whisper-ctranslate2 CLI, not faster-whisper (which ships no binary)", () => {
-    // Regression guard: a naive `pip install faster-whisper` succeeds but
-    // leaves no CLI, so execFile('faster-whisper', ...) would ENOENT at
-    // runtime. Pin the binary name so that silent mismatch can't come back.
+  // The constant itself is pinned in a brittle way — renaming the export
+  // satisfies a `toBe("whisper-ctranslate2")` check, defeating the guard.
+  // Instead assert the argv *contract* the CLI requires: audio path in
+  // position 0, flags use whisper-ctranslate2-specific spellings
+  // (underscores not dashes, capitalized boolean). The post-deploy smoke
+  // test verifies the binary is on PATH; this test locks in the flag
+  // signature so a future refactor can't drift argv incompatibly.
+  it("emits the exact argv contract whisper-ctranslate2 requires", () => {
+    const args = buildWhisperArgs("/tmp/audio.mp3");
+
+    expect(args[0]).toBe("/tmp/audio.mp3");
     expect(WHISPER_CLI).toBe("whisper-ctranslate2");
+
+    // Flag names use the whisper-ctranslate2 convention (underscores,
+    // capitalized bool). A drift to --vad-filter / true would pass an
+    // older regex-style assertion but silently fail against the real CLI.
+    const flagPairs: Record<string, string> = {};
+    for (let i = 1; i < args.length; i += 2) {
+      flagPairs[args[i]] = args[i + 1];
+    }
+    expect(flagPairs["--compute_type"]).toBe("int8");
+    expect(flagPairs["--vad_filter"]).toBe("True");
+    expect(flagPairs["--output_format"]).toBe("txt");
+    expect(flagPairs["--beam_size"]).toBe("1");
   });
 });

--- a/src/lib/__tests__/whisper.test.ts
+++ b/src/lib/__tests__/whisper.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { buildWhisperArgs } from "../whisper.js";
+import { buildWhisperArgs, WHISPER_CLI } from "../whisper.js";
 
 describe("buildWhisperArgs", () => {
-  it("builds correct faster-whisper arguments", () => {
+  it("builds correct whisper-ctranslate2 arguments", () => {
     const args = buildWhisperArgs("/tmp/audio.mp3");
     expect(args).toContain("/tmp/audio.mp3");
     expect(args).toContain("--model");
     expect(args).toContain("tiny");
     expect(args).toContain("--output_format");
     expect(args).toContain("txt");
+  });
+
+  it("targets the whisper-ctranslate2 CLI, not faster-whisper (which ships no binary)", () => {
+    // Regression guard: a naive `pip install faster-whisper` succeeds but
+    // leaves no CLI, so execFile('faster-whisper', ...) would ENOENT at
+    // runtime. Pin the binary name so that silent mismatch can't come back.
+    expect(WHISPER_CLI).toBe("whisper-ctranslate2");
   });
 });

--- a/src/lib/whisper.ts
+++ b/src/lib/whisper.ts
@@ -23,8 +23,14 @@ export function buildWhisperArgs(audioPath: string): string[] {
   ];
 }
 
+// whisper-ctranslate2 is the faster-whisper-backed CLI installed by the
+// Dockerfile. The pip package `faster-whisper` has no binary — that
+// mismatch produced a latent ENOENT at every transcribe until the
+// yt-dlp path was fixed enough to actually reach this step.
+export const WHISPER_CLI = "whisper-ctranslate2";
+
 /**
- * Transcribe an audio file using faster-whisper CLI.
+ * Transcribe an audio file using the faster-whisper-backed CLI.
  * Returns the transcript text.
  */
 export async function transcribeAudio(audioPath: string): Promise<string> {
@@ -32,18 +38,15 @@ export async function transcribeAudio(audioPath: string): Promise<string> {
     const args = buildWhisperArgs(audioPath);
 
     execFile(
-      "faster-whisper",
+      WHISPER_CLI,
       args,
       { timeout: 600_000 },
       async (error, _stdout, stderr) => {
         if (error) {
-          reject(
-            new Error(`faster-whisper failed: ${stderr || error.message}`)
-          );
+          reject(new Error(`${WHISPER_CLI} failed: ${stderr || error.message}`));
           return;
         }
 
-        // faster-whisper outputs a .txt file in the output directory
         const txtPath = join(
           tmpdir(),
           basename(audioPath).replace(/\.[^.]+$/, ".txt")

--- a/src/lib/whisper.ts
+++ b/src/lib/whisper.ts
@@ -54,8 +54,13 @@ export async function transcribeAudio(audioPath: string): Promise<string> {
 
         try {
           const transcript = await readFile(txtPath, "utf-8");
-          // Clean up the output file
-          await unlink(txtPath).catch(() => {});
+          await unlink(txtPath).catch((unlinkErr) => {
+            // Cleanup failure is non-fatal — the transcript is in-memory —
+            // but a repeated EACCES/EBUSY is a leak signal worth surfacing.
+            console.warn(
+              `[whisper] failed to unlink ${txtPath}: ${unlinkErr}`
+            );
+          });
           resolve(transcript.trim());
         } catch (readErr) {
           reject(new Error(`Failed to read transcript file: ${readErr}`));


### PR DESCRIPTION
## Summary

Transcribe was failing mid-pipeline with `spawn faster-whisper ENOENT`: the pip package `faster-whisper` is a Python library only — no `faster-whisper` binary on PATH. Replace with `whisper-ctranslate2`, the faster-whisper-backed CLI that matches the argv signature `buildWhisperArgs` already produces.

## Why it only surfaces now

Latent since the service was created. The yt-dlp datacenter-IP bot wall blocked every transcribe at step 1, so this ENOENT at step 2 never fired. PR #2's Tailscale exit-node fix unblocked yt-dlp → first real transcribe hit this.

## Changes

- `Dockerfile`: `faster-whisper` → `whisper-ctranslate2` in pip install (the former is a transitive dep of the latter, so runtime is identical)
- `src/lib/whisper.ts`: call `whisper-ctranslate2`, export `WHISPER_CLI` constant
- `src/lib/__tests__/whisper.test.ts`: regression test asserting the CLI name — catches any future "pin faster-whisper" regression silently

## Test plan

- [x] `npm test` — 14/14 passing (+1 regression guard)
- [x] `npx tsc --noEmit` — clean
- [ ] After merge: verify `docker exec youtube-ai-service which whisper-ctranslate2` returns a path
- [ ] After merge: submit a captionless video end-to-end, expect 200 + transcript

🤖 Generated with [Claude Code](https://claude.com/claude-code)