### PR TITLE
fix: force outbound IPv4 — Tailscale exit-node IPv6 is broken

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+// Must run before any HTTP client is created — see prefer-ipv4.ts for why.
+import "./lib/prefer-ipv4.js";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import { logger } from "hono/logger";

--- a/src/lib/prefer-ipv4.ts
+++ b/src/lib/prefer-ipv4.ts
@@ -1,0 +1,29 @@
+import { setDefaultResultOrder } from "dns";
+import { setDefaultAutoSelectFamily } from "net";
+
+// Force outbound connections to use IPv4. Side-effect import — run at
+// process start before any HTTP client is created.
+//
+// Root cause: our outbound traffic egresses through a Tailscale exit
+// node (a macOS home device). That exit node reliably forwards IPv4
+// but IPv6 forwarding is flaky — packets to Google's IPv6 addresses
+// (youtube.com has AAAA records) time out silently. Node's undici
+// (backing `fetch`) does Happy Eyeballs across families; when the
+// IPv6 path hangs instead of refusing, the TCP connect stalls long
+// past any practical timeout before falling through to IPv4.
+//
+// Two-part fix:
+//   1. `setDefaultResultOrder("ipv4first")` — dns.lookup returns A
+//      records before AAAA.
+//   2. `setDefaultAutoSelectFamily(false)` — net.connect uses only
+//      the FIRST resolved address, not Happy Eyeballs across all
+//      addresses. Combined with (1), Node always picks the first
+//      IPv4 address and never tries IPv6.
+//
+// Verified: before this init `fetch("https://www.youtube.com")` from
+// the container ETIMEDOUT; after, it returns 200.
+//
+// If the exit-node IPv6 path ever becomes reliable, this can be
+// removed without changing any caller code.
+setDefaultResultOrder("ipv4first");
+setDefaultAutoSelectFamily(false);


### PR DESCRIPTION
## Summary

Captions smoke failed on PR #7 deploy with `fetch failed: ETIMEDOUT` even though the Tailscale tunnel was healthy. Root cause: the macOS exit node forwards IPv4 fine but its IPv6 forwarding hangs silently, and Node's undici Happy Eyeballs stalls on the IPv6 attempt instead of falling through to IPv4.

## Diagnosis (all from app container)

```
curl https://www.youtube.com/          → 200 in 3s
node https.get(youtube.com)            → ETIMEDOUT
net.connect({host, port, family: 4})   → OK
net.connect({host, port})  (default)   → ETIMEDOUT
```

## Fix

`src/lib/prefer-ipv4.ts`:
- `dns.setDefaultResultOrder("ipv4first")` — A before AAAA
- `net.setDefaultAutoSelectFamily(false)` — connect uses only the first resolved address

Side-effect-imported first in `index.ts` so every HTTP client (undici/fetch, https.get, third-party libs) inherits it. Pure defensive init — if the exit node ever gets working IPv6, this file can be deleted.

## Test plan

- [x] `npm test` 79/79 passing
- [x] `npx tsc --noEmit` clean
- [ ] After merge: captions smoke returns 200 (currently fails with ETIMEDOUT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)