### PR TITLE
feat: language-pinned transcript extraction (captions + whisper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ Lightweight transcription microservice. Part of the YouTube AI Chat stack.
 
 ## Endpoints
 
-- `POST /captions` — Fetch YouTube auto-captions for a video. Returns 200 with `{ transcript, source, language, title, channelName }` or 404 `{ error: "no_captions" }` if the video has none. Much cheaper than transcription — call this first.
-- `POST /transcribe` — Download audio via yt-dlp and transcribe with whisper-ctranslate2. Fallback when captions aren't available.
+- `POST /metadata` — Extract video metadata (title, description, detected language, available caption track codes) via `yt-dlp --dump-json`. Call this first so the orchestrator can pin caption + whisper language and avoid the default "pick tracks[0]" bug that produced wrong-language transcripts.
+- `POST /captions` — Fetch YouTube auto-captions for a video. Accepts an optional `lang` (ISO 639-1 or BCP-47) that forwards to `youtube-transcript-plus` so a specific caption track is selected. Returns 200 with `{ transcript, source, language, title, channelName }` or 404 `{ error: "no_captions" }` if the track isn't available. Much cheaper than transcription — call this before `/transcribe`.
+- `POST /transcribe` — Download audio via yt-dlp and transcribe with whisper-ctranslate2. Accepts an optional `lang` that forwards to whisper as `--language <code>` to bypass auto-detect. Fallback when captions aren't available.
 - `GET /health` — Health check (unauthenticated).
 
-Both data endpoints require `Authorization: Bearer <VPS_API_KEY>`.
+All data endpoints require `Authorization: Bearer <VPS_API_KEY>`.
 
 ## Tech
 
-Node.js 22, Hono, Python (faster-whisper), yt-dlp, ffmpeg. Runs in Docker.
+Node.js 22, Hono, Python (faster-whisper), yt-dlp, ffmpeg, `franc` for text-based language detection. Runs in Docker.
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
+        "franc": "^6.2.0",
         "hono": "^4.6.0",
         "youtube-transcript-plus": "^2.0.0",
         "zod": "^3.25.0"
@@ -1029,6 +1030,16 @@
         "node": ">= 16"
       }
     },
+    "node_modules/collapse-white-space": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1144,6 +1155,19 @@
         }
       }
     },
+    "node_modules/franc": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/franc/-/franc-6.2.0.tgz",
+      "integrity": "sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==",
+      "license": "MIT",
+      "dependencies": {
+        "trigram-utils": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1212,6 +1236,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/n-gram": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+      "integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1457,6 +1491,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/trigram-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
+      "integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "collapse-white-space": "^2.0.0",
+        "n-gram": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.0",
+    "franc": "^6.2.0",
     "hono": "^4.6.0",
     "youtube-transcript-plus": "^2.0.0",
     "zod": "^3.25.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { logger } from "hono/logger";
 import { health } from "./routes/health.js";
 import { transcribe } from "./routes/transcribe.js";
 import { captions } from "./routes/captions.js";
+import { metadata } from "./routes/metadata.js";
 
 const app = new Hono();
 
@@ -21,6 +22,7 @@ app.route("/", health);
 // path. Mounting at `/` would make auth fire on /health too.
 app.route("/transcribe", transcribe);
 app.route("/captions", captions);
+app.route("/metadata", metadata);
 
 const port = parseInt(process.env.PORT || "3001", 10);
 

--- a/src/lib/__tests__/captions.test.ts
+++ b/src/lib/__tests__/captions.test.ts
@@ -256,4 +256,25 @@ describe("fetchCaptions", () => {
       channelName: "a",
     });
   });
+
+  it("omits `lang` in the library call when the caller didn't provide one (back-compat)", async () => {
+    // Without this guard a future refactor could pass `{ lang: undefined }`,
+    // which the library treats as a real filter and rejects with
+    // NotAvailableLanguage — breaking the current "first track wins" flow
+    // that existing callers depend on.
+    mockedFetchTranscript.mockResolvedValue(ok([{ text: "hi", lang: "en" }]));
+    await fetchCaptions("https://youtu.be/dQw4w9WgXcQ");
+    const call = mockedFetchTranscript.mock.calls[0];
+    expect(call[1]).toEqual({ videoDetails: true });
+    expect(call[1]).not.toHaveProperty("lang");
+  });
+
+  it("forwards `lang` to the library when provided (pins caption track)", async () => {
+    // The whole point of this parameter: without it, the library picks
+    // `tracks[0]` which for some videos is the wrong language entirely.
+    mockedFetchTranscript.mockResolvedValue(ok([{ text: "bonjour", lang: "fr" }]));
+    await fetchCaptions("https://youtu.be/dQw4w9WgXcQ", "fr");
+    const call = mockedFetchTranscript.mock.calls[0];
+    expect(call[1]).toEqual({ videoDetails: true, lang: "fr" });
+  });
 });

--- a/src/lib/__tests__/language-detect.test.ts
+++ b/src/lib/__tests__/language-detect.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   detectLanguage,
   normalizeLanguageCode,
@@ -51,6 +51,15 @@ describe("normalizeLanguageCode", () => {
     expect(normalizeLanguageCode(null)).toBeNull();
     expect(normalizeLanguageCode(undefined)).toBeNull();
   });
+
+  it.each([["zxx"], ["mul"], ["mis"], ["ZXX"], ["Mul"]])(
+    "treats yt-dlp sentinel %s as no-signal (null)",
+    (code) => {
+      // These codes reach whisper as `--language zxx` and produce cryptic
+      // CLI errors. Fall through rather than forward garbage.
+      expect(normalizeLanguageCode(code)).toBeNull();
+    }
+  );
 });
 
 describe("detectLanguage", () => {
@@ -116,8 +125,38 @@ describe("detectLanguage", () => {
   });
 
   it("falls back to 'en' when text is too short for confident detection", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const result = detectLanguage({ ...base, title: "Hi", description: "" });
     expect(result).toBe("en");
+  });
+
+  it("logs LANGUAGE_DETECT_FALLBACK with context when every signal fails", async () => {
+    // A silent "en" here defeats the whole point of the PR — a rising
+    // miss rate should be alertable. Lock the errorId + context shape
+    // so a future refactor can't drop the log.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    detectLanguage({ ...base, title: "Hi", description: "" });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("fallback to en"),
+      expect.objectContaining({
+        errorId: "LANGUAGE_DETECT_FALLBACK",
+        hasLanguageField: false,
+        subtitleKeyCount: 0,
+      })
+    );
+  });
+
+  it("falls through to text detection when the sole subtitle key is unnormalizable", () => {
+    // A subtitle track with a bogus key like "??" must NOT short-circuit
+    // the priority chain — the fallback to text detection is the whole
+    // point of having multiple signals.
+    const result = detectLanguage({
+      ...base,
+      subtitles: { "??": [{ url: "x", ext: "vtt" }] },
+      description:
+        "Ceci est un texte en français suffisamment long pour que la détection fonctionne correctement. Nous allons explorer plusieurs concepts.",
+    });
+    expect(result).toBe("fr");
   });
 
   it("does NOT treat automatic_captions keys as a language signal", () => {
@@ -125,6 +164,7 @@ describe("detectLanguage", () => {
     // regardless of the source language. Trusting this field would let a
     // captioned French video get labelled English (alphabetically first)
     // or arbitrary.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const result = detectLanguage({
       ...base,
       automatic_captions: {

--- a/src/lib/__tests__/language-detect.test.ts
+++ b/src/lib/__tests__/language-detect.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectLanguage,
+  normalizeLanguageCode,
+  extractAvailableCaptions,
+  type YtdlpMetadata,
+} from "../language-detect.js";
+
+const base: YtdlpMetadata = {
+  title: "",
+  description: "",
+  language: null,
+  subtitles: {},
+  automatic_captions: {},
+};
+
+describe("normalizeLanguageCode", () => {
+  it.each([
+    ["en", "en"],
+    ["EN", "en"],
+    ["en-US", "en"],
+    ["en-gb", "en"],
+    ["fr-FR", "fr"],
+    ["zh-CN", "zh"],
+    ["zh-TW", "zh"],
+    ["zh-Hans", "zh"],
+    // ISO 639-3 three-letter codes franc returns — map to 639-1 where we
+    // have a concrete mapping. Unknown 639-3 codes pass through unchanged
+    // rather than silently collapsing to "en", so the caller can log + fall
+    // through to the ultimate fallback instead of masking an unknown lang
+    // as English.
+    ["fra", "fr"],
+    ["eng", "en"],
+    ["cmn", "zh"],
+    ["spa", "es"],
+    ["jpn", "ja"],
+    ["kor", "ko"],
+    ["deu", "de"],
+    ["por", "pt"],
+    ["rus", "ru"],
+    ["ita", "it"],
+    ["ara", "ar"],
+    ["hin", "hi"],
+  ])("normalizes %s → %s", (input, expected) => {
+    expect(normalizeLanguageCode(input)).toBe(expected);
+  });
+
+  it("returns null for empty / und / bogus input", () => {
+    expect(normalizeLanguageCode("")).toBeNull();
+    expect(normalizeLanguageCode("und")).toBeNull();
+    expect(normalizeLanguageCode(null)).toBeNull();
+    expect(normalizeLanguageCode(undefined)).toBeNull();
+  });
+});
+
+describe("detectLanguage", () => {
+  it("trusts the yt-dlp `language` field when present (highest priority)", () => {
+    const result = detectLanguage({
+      ...base,
+      language: "fr",
+      description: "This is clearly English text, lots of it, more than enough",
+    });
+    // Even when description language disagrees, the uploader-specified
+    // `language` field wins — it's authoritative while text detection is
+    // heuristic.
+    expect(result).toBe("fr");
+  });
+
+  it("normalizes yt-dlp `language` to ISO 639-1 primary subtag", () => {
+    expect(detectLanguage({ ...base, language: "zh-Hans" })).toBe("zh");
+    expect(detectLanguage({ ...base, language: "en-US" })).toBe("en");
+  });
+
+  it("uses the sole manually-uploaded subtitle track as signal when language is absent", () => {
+    const result = detectLanguage({
+      ...base,
+      subtitles: { fr: [{ url: "x", ext: "vtt" }] },
+    });
+    expect(result).toBe("fr");
+  });
+
+  it("does NOT use subtitles when multiple manual tracks exist (ambiguous)", () => {
+    // Uploaders commonly upload BOTH the source language and an English
+    // translation — picking one arbitrarily would reintroduce the exact
+    // bug class we're fixing.
+    const result = detectLanguage({
+      ...base,
+      subtitles: {
+        fr: [{ url: "x", ext: "vtt" }],
+        en: [{ url: "y", ext: "vtt" }],
+      },
+      description:
+        "Ceci est un texte en français suffisamment long pour que la détection fonctionne correctement.",
+    });
+    expect(result).toBe("fr");
+  });
+
+  it("falls back to text detection on description + title", () => {
+    const result = detectLanguage({
+      ...base,
+      title: "Comment apprendre la programmation",
+      description:
+        "Ceci est un texte en français suffisamment long pour que la détection fonctionne correctement. Nous allons explorer les bases du développement logiciel et des concepts essentiels.",
+    });
+    expect(result).toBe("fr");
+  });
+
+  it("detects Chinese via text detection and collapses to zh", () => {
+    const result = detectLanguage({
+      ...base,
+      title: "如何学习编程",
+      description:
+        "这是一段中文文字，用于测试语言检测功能。我们将探讨编程的基础知识和一些重要的概念。请仔细阅读以下内容。",
+    });
+    expect(result).toBe("zh");
+  });
+
+  it("falls back to 'en' when text is too short for confident detection", () => {
+    const result = detectLanguage({ ...base, title: "Hi", description: "" });
+    expect(result).toBe("en");
+  });
+
+  it("does NOT treat automatic_captions keys as a language signal", () => {
+    // YouTube populates automatic_captions with many translated variants
+    // regardless of the source language. Trusting this field would let a
+    // captioned French video get labelled English (alphabetically first)
+    // or arbitrary.
+    const result = detectLanguage({
+      ...base,
+      automatic_captions: {
+        ar: [{ url: "x", ext: "vtt" }],
+        en: [{ url: "x", ext: "vtt" }],
+        fr: [{ url: "x", ext: "vtt" }],
+      },
+    });
+    expect(result).toBe("en"); // ultimate fallback (no other signal)
+  });
+});
+
+describe("extractAvailableCaptions", () => {
+  it("returns union of subtitles and automatic_captions keys, normalized", () => {
+    const result = extractAvailableCaptions({
+      ...base,
+      subtitles: { fr: [{ url: "x", ext: "vtt" }] },
+      automatic_captions: {
+        "en-US": [{ url: "x", ext: "vtt" }],
+        "zh-CN": [{ url: "x", ext: "vtt" }],
+      },
+    });
+    expect(result).toEqual(expect.arrayContaining(["fr", "en", "zh"]));
+    // Deduplicated: same normalized code shouldn't appear twice.
+    expect(result.length).toBe(new Set(result).size);
+  });
+
+  it("returns empty array when both dicts are empty", () => {
+    expect(extractAvailableCaptions(base)).toEqual([]);
+  });
+});

--- a/src/lib/__tests__/whisper.test.ts
+++ b/src/lib/__tests__/whisper.test.ts
@@ -36,4 +36,27 @@ describe("buildWhisperArgs", () => {
     expect(flagPairs["--output_format"]).toBe("txt");
     expect(flagPairs["--beam_size"]).toBe("1");
   });
+
+  it("omits --language when no lang provided (preserves whisper auto-detect default)", () => {
+    // Back-compat: callers that don't pass lang must see exactly the same
+    // argv as before, so whisper's built-in language detection continues
+    // to run. A stray --language flag would silently override that.
+    const args = buildWhisperArgs("/tmp/audio.mp3");
+    expect(args).not.toContain("--language");
+  });
+
+  it("emits --language <code> when a lang is provided", () => {
+    // whisper-ctranslate2 accepts ISO 639-1 codes directly. The flag form
+    // is `--language fr` (space-separated, not `=fr`).
+    const args = buildWhisperArgs("/tmp/audio.mp3", "fr");
+    const langIdx = args.indexOf("--language");
+    expect(langIdx).toBeGreaterThan(-1);
+    expect(args[langIdx + 1]).toBe("fr");
+  });
+
+  it("emits --language for zh path (ensures CJK languages survive normalization)", () => {
+    const args = buildWhisperArgs("/tmp/audio.mp3", "zh");
+    const langIdx = args.indexOf("--language");
+    expect(args[langIdx + 1]).toBe("zh");
+  });
 });

--- a/src/lib/__tests__/ytdlp-metadata.test.ts
+++ b/src/lib/__tests__/ytdlp-metadata.test.ts
@@ -133,6 +133,33 @@ describe("fetchYtdlpMetadata", () => {
     ).rejects.toThrow();
   });
 
+  it("throws when stdout parses but has no anchor fields (schema regression guard)", async () => {
+    // A `{}` response looks like a successful empty video — no id, no
+    // title, no URL. Collapsing it to all-defaults would let the route
+    // return 200 and the orchestrator would pin an arbitrary language
+    // to whisper. Catch the regression here at the boundary.
+    mockExecSuccess(JSON.stringify({}));
+    await expect(
+      fetchYtdlpMetadata("https://youtu.be/abc")
+    ).rejects.toThrow(/anchor/);
+  });
+
+  it("throws when stdout is a JSON array instead of object", async () => {
+    mockExecSuccess(JSON.stringify([]));
+    await expect(
+      fetchYtdlpMetadata("https://youtu.be/abc")
+    ).rejects.toThrow(/non-object/);
+  });
+
+  it("accepts a payload with `id` only (yt-dlp minimum)", async () => {
+    // Some uploads have no description, no uploader, no language — but
+    // every real video has an `id`. Don't over-tighten the guard.
+    mockExecSuccess(JSON.stringify({ id: "abc123" }));
+    const result = await fetchYtdlpMetadata("https://youtu.be/abc");
+    expect(result.title).toBe("");
+    expect(result.language).toBeNull();
+  });
+
   it("truncates very long descriptions to 2000 chars", async () => {
     // yt-dlp's `description` is unbounded user content. Long descriptions
     // bloat JSON responses and log lines; 2000 chars is more than enough

--- a/src/lib/__tests__/ytdlp-metadata.test.ts
+++ b/src/lib/__tests__/ytdlp-metadata.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildYtdlpMetadataArgs,
+  fetchYtdlpMetadata,
+} from "../ytdlp-metadata.js";
+import { POT_PROVIDER_URL } from "../ytdlp-common.js";
+
+// ESM module spying requires vi.mock at module scope — vi.spyOn on an
+// imported namespace fails with "Module namespace is not configurable".
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from "child_process";
+const mockedExecFile = vi.mocked(execFile);
+
+describe("buildYtdlpMetadataArgs", () => {
+  it("includes --dump-json and --skip-download (the whole point — no audio transfer)", () => {
+    const args = buildYtdlpMetadataArgs("https://youtu.be/abc");
+    expect(args).toContain("--dump-json");
+    expect(args).toContain("--skip-download");
+  });
+
+  it("reuses the same player_client profile as the audio download path", () => {
+    // If these drift, the metadata path would hit YouTube's bot wall while
+    // the download path works — producing a false "no language signal"
+    // every time. Lock them to the same profile.
+    const args = buildYtdlpMetadataArgs("https://youtu.be/abc");
+    const extractorArgValues = args
+      .map((a, i) => (a === "--extractor-args" ? args[i + 1] : null))
+      .filter((v): v is string => v !== null);
+
+    expect(
+      extractorArgValues.some((v) => v.startsWith("youtube:player_client="))
+    ).toBe(true);
+    expect(extractorArgValues).toContain(
+      `youtubepot-bgutilhttp:base_url=${POT_PROVIDER_URL}`
+    );
+  });
+
+  it("sets a browser User-Agent matching the audio-path profile", () => {
+    const args = buildYtdlpMetadataArgs("https://youtu.be/abc");
+    const uaIdx = args.indexOf("--user-agent");
+    expect(uaIdx).toBeGreaterThan(-1);
+    expect(args[uaIdx + 1]).toMatch(/Mozilla\//);
+  });
+
+  it("puts the URL last (yt-dlp positional arg convention)", () => {
+    const args = buildYtdlpMetadataArgs("https://youtu.be/abc");
+    expect(args[args.length - 1]).toBe("https://youtu.be/abc");
+  });
+});
+
+describe("fetchYtdlpMetadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const mockExecSuccess = (stdout: string) => {
+    mockedExecFile.mockImplementation(
+      // @ts-expect-error execFile overloads don't narrow cleanly in mock
+      (_cmd, _args, _opts, cb) => {
+        cb?.(null, stdout, "");
+      }
+    );
+  };
+
+  const mockExecFailure = (error: Error, stderr = "") => {
+    mockedExecFile.mockImplementation(
+      // @ts-expect-error execFile overloads don't narrow cleanly in mock
+      (_cmd, _args, _opts, cb) => {
+        cb?.(error, "", stderr);
+      }
+    );
+  };
+
+  it("returns parsed metadata on success", async () => {
+    mockExecSuccess(
+      JSON.stringify({
+        title: "Test Video",
+        description: "A test video",
+        language: "fr",
+        subtitles: { fr: [{ url: "x", ext: "vtt" }] },
+        automatic_captions: { en: [{ url: "y", ext: "vtt" }] },
+      })
+    );
+    const result = await fetchYtdlpMetadata("https://youtu.be/abc");
+    expect(result.title).toBe("Test Video");
+    expect(result.description).toBe("A test video");
+    expect(result.language).toBe("fr");
+    expect(result.subtitles).toEqual({ fr: [{ url: "x", ext: "vtt" }] });
+    expect(result.automatic_captions).toEqual({
+      en: [{ url: "y", ext: "vtt" }],
+    });
+  });
+
+  it("normalizes missing fields to safe defaults", async () => {
+    // yt-dlp omits `language`, `description`, `subtitles`,
+    // `automatic_captions` for videos where those are empty — not returning
+    // null. Our downstream consumers expect the fields to exist, so
+    // normalize here rather than scattering optional-chaining everywhere.
+    mockExecSuccess(JSON.stringify({ title: "Only Title" }));
+    const result = await fetchYtdlpMetadata("https://youtu.be/abc");
+    expect(result.title).toBe("Only Title");
+    expect(result.description).toBe("");
+    expect(result.language).toBeNull();
+    expect(result.subtitles).toEqual({});
+    expect(result.automatic_captions).toEqual({});
+  });
+
+  it("throws when yt-dlp exits non-zero", async () => {
+    // Propagating the error lets the route return 500 instead of silently
+    // falling back to whisper without language hint. If this swallowed the
+    // error, a persistent yt-dlp issue would be invisible except as a
+    // rising cost-per-request.
+    mockExecFailure(new Error("yt-dlp exit 1"), "ERROR: unavailable");
+    await expect(
+      fetchYtdlpMetadata("https://youtu.be/abc")
+    ).rejects.toThrow(/yt-dlp/);
+  });
+
+  it("throws when stdout isn't valid JSON", async () => {
+    // Silent JSON-parse fallback would produce a metadata object with all
+    // defaults, matching the "no signal" case — hiding a real extraction
+    // failure. Throw so the route can log + return 500.
+    mockExecSuccess("not json at all");
+    await expect(
+      fetchYtdlpMetadata("https://youtu.be/abc")
+    ).rejects.toThrow();
+  });
+
+  it("truncates very long descriptions to 2000 chars", async () => {
+    // yt-dlp's `description` is unbounded user content. Long descriptions
+    // bloat JSON responses and log lines; 2000 chars is more than enough
+    // for language detection and human-readable logging.
+    const longDescription = "x".repeat(5000);
+    mockExecSuccess(
+      JSON.stringify({ title: "t", description: longDescription })
+    );
+    const result = await fetchYtdlpMetadata("https://youtu.be/abc");
+    expect(result.description.length).toBe(2000);
+  });
+});

--- a/src/lib/captions.ts
+++ b/src/lib/captions.ts
@@ -87,6 +87,10 @@ export function pickLocale(
 /**
  * Fetch auto-captions for a YouTube URL.
  *
+ * When `lang` is provided, forwards it to the library so the specific
+ * caption track is selected instead of `tracks[0]` (which YouTube can
+ * order arbitrarily — the bug that produced Arabic for French videos).
+ *
  * Returns `null` for the expected "no captions available" outcome (the
  * frontend falls back to Whisper transcription). Throws on unexpected
  * library or network failures so the route can return 5xx — a blanket
@@ -94,14 +98,18 @@ export function pickLocale(
  * hiding real problems behind compute bills.
  */
 export async function fetchCaptions(
-  youtubeUrl: string
+  youtubeUrl: string,
+  lang?: string
 ): Promise<CaptionResult | null> {
   const videoId = extractVideoId(youtubeUrl);
   if (!videoId) return null;
 
   let result: TranscriptResult;
   try {
-    const response = await fetchTranscript(videoId, { videoDetails: true });
+    const response = await fetchTranscript(videoId, {
+      videoDetails: true,
+      ...(lang ? { lang } : {}),
+    });
     result = response as TranscriptResult;
   } catch (err) {
     if (isExpectedNoCaptions(err)) return null;

--- a/src/lib/language-detect.ts
+++ b/src/lib/language-detect.ts
@@ -1,0 +1,133 @@
+import { franc } from "franc";
+
+// Minimum character count before we trust franc's output. Below this, franc's
+// trigram model produces noisy results (short text often mis-detects as an
+// exotic language). 30 chars is the library's own documented threshold.
+const MIN_TEXT_DETECTION_LENGTH = 30;
+
+// Codes we map from franc's ISO 639-3 output to ISO 639-1 (what whisper and
+// YouTube caption tracks use). Only languages with concrete 639-1 mappings —
+// unlisted 639-3 codes pass through unchanged so the caller can log and
+// fall through to the ultimate fallback rather than silently lying.
+const ISO_639_3_TO_1: Record<string, string> = {
+  eng: "en",
+  cmn: "zh",
+  fra: "fr",
+  spa: "es",
+  jpn: "ja",
+  kor: "ko",
+  deu: "de",
+  por: "pt",
+  rus: "ru",
+  ita: "it",
+  ara: "ar",
+  hin: "hi",
+  nld: "nl",
+  tur: "tr",
+  vie: "vi",
+  ind: "id",
+  tha: "th",
+  pol: "pl",
+  ukr: "uk",
+  swe: "sv",
+  dan: "da",
+  nor: "no",
+  fin: "fi",
+  ces: "cs",
+  ell: "el",
+  heb: "he",
+  ron: "ro",
+  hun: "hu",
+};
+
+export interface YtdlpCaptionTrack {
+  readonly url: string;
+  readonly ext: string;
+}
+
+// Subset of yt-dlp JSON we actually consume. Accepting arbitrary extra keys
+// keeps us forward-compatible with yt-dlp schema changes.
+export interface YtdlpMetadata {
+  readonly title: string;
+  readonly description: string;
+  readonly language: string | null;
+  readonly subtitles: Readonly<Record<string, readonly YtdlpCaptionTrack[]>>;
+  readonly automatic_captions: Readonly<
+    Record<string, readonly YtdlpCaptionTrack[]>
+  >;
+}
+
+/**
+ * Normalize a language tag to ISO 639-1 primary subtag (lowercase 2-letter).
+ * Accepts BCP-47 (`en-US` → `en`, `zh-Hans` → `zh`) and ISO 639-3 (`fra` →
+ * `fr`, via the mapping table). Returns `null` for empty, `und`, or
+ * unrecognized codes — callers treat null as "no signal" and fall through.
+ */
+export function normalizeLanguageCode(code: string | null | undefined): string | null {
+  if (!code) return null;
+  const lower = code.toLowerCase().trim();
+  if (!lower || lower === "und") return null;
+
+  // Primary subtag already: "en", "fr", etc. Accept any 2-char lowercase.
+  if (/^[a-z]{2}$/.test(lower)) return lower;
+
+  // BCP-47 with region/script: "en-US", "zh-Hans". Take the primary subtag.
+  const match = lower.match(/^([a-z]{2,3})(?:-.+)?$/);
+  if (!match) return null;
+  const primary = match[1];
+
+  if (primary.length === 2) return primary;
+
+  // ISO 639-3 three-letter: map via table, else null (no silent fallback —
+  // callers can log and try the next signal).
+  return ISO_639_3_TO_1[primary] ?? null;
+}
+
+/**
+ * Derive the video's language from yt-dlp metadata. Priority order:
+ *   1. `language` field (uploader-specified, authoritative).
+ *   2. Sole manually-uploaded subtitle track (strong correlate of source lang).
+ *   3. Text detection on description + title via franc (heuristic fallback).
+ *   4. "en" ultimate fallback.
+ *
+ * `automatic_captions` is NOT used as a signal — YouTube populates it with
+ * many auto-translations regardless of source language.
+ */
+export function detectLanguage(metadata: YtdlpMetadata): string {
+  const fromLanguage = normalizeLanguageCode(metadata.language);
+  if (fromLanguage) return fromLanguage;
+
+  const subtitleKeys = Object.keys(metadata.subtitles);
+  if (subtitleKeys.length === 1) {
+    const normalized = normalizeLanguageCode(subtitleKeys[0]);
+    if (normalized) return normalized;
+  }
+
+  const text = `${metadata.title ?? ""} ${metadata.description ?? ""}`.trim();
+  if (text.length >= MIN_TEXT_DETECTION_LENGTH) {
+    const francResult = franc(text);
+    const normalized = normalizeLanguageCode(francResult);
+    if (normalized) return normalized;
+  }
+
+  return "en";
+}
+
+/**
+ * Collect every caption language the video has at least one track for —
+ * union of `subtitles` and `automatic_captions` keys, normalized to ISO
+ * 639-1, deduplicated. Feeds the orchestrator's "try English as a
+ * fallback before whisper" decision.
+ */
+export function extractAvailableCaptions(metadata: YtdlpMetadata): string[] {
+  const codes = new Set<string>();
+  for (const key of Object.keys(metadata.subtitles)) {
+    const normalized = normalizeLanguageCode(key);
+    if (normalized) codes.add(normalized);
+  }
+  for (const key of Object.keys(metadata.automatic_captions)) {
+    const normalized = normalizeLanguageCode(key);
+    if (normalized) codes.add(normalized);
+  }
+  return Array.from(codes);
+}

--- a/src/lib/language-detect.ts
+++ b/src/lib/language-detect.ts
@@ -57,16 +57,27 @@ export interface YtdlpMetadata {
   >;
 }
 
+// yt-dlp / franc sentinels that mean "no linguistic content" or "ambiguous" —
+// forwarding any of these to whisper as `--language zxx` produces a cryptic
+// CLI error. Treat as "no signal" and let callers fall through.
+const LANGUAGE_SENTINELS: ReadonlySet<string> = new Set([
+  "und", // undetermined — franc's "couldn't detect" output
+  "zxx", // no linguistic content — yt-dlp uses this for music-only tracks
+  "mul", // multiple languages
+  "mis", // uncoded languages
+]);
+
 /**
  * Normalize a language tag to ISO 639-1 primary subtag (lowercase 2-letter).
- * Accepts BCP-47 (`en-US` → `en`, `zh-Hans` → `zh`) and ISO 639-3 (`fra` →
- * `fr`, via the mapping table). Returns `null` for empty, `und`, or
- * unrecognized codes — callers treat null as "no signal" and fall through.
+ * Accepts BCP-47 2-letter-primary tags (`en-US` → `en`, `zh-Hans` → `zh`)
+ * through the regex branch, and ISO 639-3 3-letter codes (`fra` → `fr`) via
+ * the mapping table. Returns `null` for empty, sentinels (und/zxx/mul/mis),
+ * or unrecognized codes — callers treat null as "no signal" and fall through.
  */
 export function normalizeLanguageCode(code: string | null | undefined): string | null {
   if (!code) return null;
   const lower = code.toLowerCase().trim();
-  if (!lower || lower === "und") return null;
+  if (!lower || LANGUAGE_SENTINELS.has(lower)) return null;
 
   // Primary subtag already: "en", "fr", etc. Accept any 2-char lowercase.
   if (/^[a-z]{2}$/.test(lower)) return lower;
@@ -86,9 +97,13 @@ export function normalizeLanguageCode(code: string | null | undefined): string |
 /**
  * Derive the video's language from yt-dlp metadata. Priority order:
  *   1. `language` field (uploader-specified, authoritative).
- *   2. Sole manually-uploaded subtitle track (strong correlate of source lang).
+ *   2. Sole manually-uploaded subtitle track (2+ tracks is ambiguous — a
+ *      French-source uploader often ships fr + en, and picking one
+ *      arbitrarily reintroduces the tracks[0] bug class).
  *   3. Text detection on description + title via franc (heuristic fallback).
- *   4. "en" ultimate fallback.
+ *   4. `"en"` ultimate fallback, with a warn log so a high miss rate is
+ *      observable in production (a rising rate is a detection-quality
+ *      regression or a corpus of metadata-sparse videos we should fix).
  *
  * `automatic_captions` is NOT used as a signal — YouTube populates it with
  * many auto-translations regardless of source language.
@@ -101,15 +116,28 @@ export function detectLanguage(metadata: YtdlpMetadata): string {
   if (subtitleKeys.length === 1) {
     const normalized = normalizeLanguageCode(subtitleKeys[0]);
     if (normalized) return normalized;
+    // Unnormalizable single key (e.g. "??", "zxx") — fall through to
+    // text detection rather than trusting the bogus signal.
   }
 
   const text = `${metadata.title ?? ""} ${metadata.description ?? ""}`.trim();
+  let francResult: string | null = null;
   if (text.length >= MIN_TEXT_DETECTION_LENGTH) {
-    const francResult = franc(text);
+    francResult = franc(text);
     const normalized = normalizeLanguageCode(francResult);
     if (normalized) return normalized;
   }
 
+  // Everything failed. Log the fallback so a rising miss rate is alertable —
+  // a silent "en" here defeats the PR's purpose of pinning the right
+  // language to whisper.
+  console.warn("[language-detect] fallback to en (no usable signal)", {
+    errorId: "LANGUAGE_DETECT_FALLBACK",
+    hasLanguageField: Boolean(metadata.language),
+    subtitleKeyCount: subtitleKeys.length,
+    textLength: text.length,
+    francResult,
+  });
   return "en";
 }
 

--- a/src/lib/whisper.ts
+++ b/src/lib/whisper.ts
@@ -3,8 +3,8 @@ import { readFile, unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join, basename } from "path";
 
-export function buildWhisperArgs(audioPath: string): string[] {
-  return [
+export function buildWhisperArgs(audioPath: string, lang?: string): string[] {
+  const args = [
     audioPath,
     "--model",
     "tiny",
@@ -21,6 +21,17 @@ export function buildWhisperArgs(audioPath: string): string[] {
     "--output_dir",
     tmpdir(),
   ];
+  // Pinning --language protects against whisper's auto-detect misfiring on
+  // short or noisy clips (the bug that produced Arabic transcripts for
+  // French audio before this flag was threaded through). Callers should
+  // only pass lang when they have a high-confidence source — uploader
+  // metadata or yt-dlp's extracted `language`. A wrong hint would force
+  // whisper to mis-transcribe cleanly rather than guess, so "no hint" is
+  // still the safer default when confidence is low.
+  if (lang) {
+    args.push("--language", lang);
+  }
+  return args;
 }
 
 // whisper-ctranslate2 is the faster-whisper-backed CLI installed by the
@@ -31,11 +42,17 @@ export const WHISPER_CLI = "whisper-ctranslate2";
 
 /**
  * Transcribe an audio file using the faster-whisper-backed CLI.
- * Returns the transcript text.
+ * When `lang` is provided, whisper's auto-detect is bypassed and the
+ * transcription is forced into the named language — used when the
+ * orchestrator has a high-confidence signal (yt-dlp metadata) and wants
+ * to avoid whisper misfiring on short/noisy audio.
  */
-export async function transcribeAudio(audioPath: string): Promise<string> {
+export async function transcribeAudio(
+  audioPath: string,
+  lang?: string
+): Promise<string> {
   return new Promise((resolve, reject) => {
-    const args = buildWhisperArgs(audioPath);
+    const args = buildWhisperArgs(audioPath, lang);
 
     execFile(
       WHISPER_CLI,

--- a/src/lib/youtube-url.ts
+++ b/src/lib/youtube-url.ts
@@ -34,3 +34,16 @@ export const youtubeUrlSchema = z
   .refine(isYoutubeUrl, {
     message: "URL must be a YouTube URL",
   });
+
+// BCP-47 primary subtag + optional region/script (e.g. "en", "fra", "en-US",
+// "zh-Hans", "zh-Hant-TW"). Pinned at the schema boundary so arbitrary
+// strings ("--model", " ; rm -rf /", emoji) never reach child_process.
+// execFile with an argv array already blocks shell injection — this
+// regex blocks the narrower class of "lang that looks like a CLI flag"
+// that would produce confusing whisper errors instead of clean rejection.
+export const languageCodeSchema = z
+  .string()
+  .regex(
+    /^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{2,8})*$/,
+    "lang must be a BCP-47 tag (e.g. en, fr, zh-Hans)"
+  );

--- a/src/lib/ytdlp-common.ts
+++ b/src/lib/ytdlp-common.ts
@@ -1,0 +1,40 @@
+// Flags and constants shared between yt-dlp invocations (audio download,
+// metadata dump). Extracted so `buildYtdlpArgs` and `buildYtdlpMetadataArgs`
+// can't drift out of sync — a player_client or PO Token change made in one
+// call path must apply to the other.
+
+// Datacenter IPs frequently hit YouTube's "Sign in to confirm you're not a
+// bot" wall when yt-dlp uses the default `web` player client. Cycling
+// through alternate clients (mweb / web_safari / android_vr) unblocks most
+// requests when combined with a residential-IP egress path (Tailscale exit
+// node → home device, wired in docker-compose.yml).
+export const YOUTUBE_PLAYER_CLIENTS = "web_safari,mweb,android_vr";
+
+// Pair the client list with a browser UA so the request profile matches.
+export const SAFARI_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+// Proof-of-Origin Token provider. `pot-provider` is the sibling container
+// (see docker-compose.yml) that shares our network namespace, so it's
+// reachable on localhost. YouTube enforces PO Tokens across multiple
+// extraction paths — without this, requests fail regardless of IP
+// reputation or cookie state. Override via env for local dev or if the
+// sidecar's bind address changes.
+export const POT_PROVIDER_URL =
+  process.env.POT_PROVIDER_URL ?? "http://127.0.0.1:4416";
+
+/**
+ * Common flags every yt-dlp invocation shares: playlist guard, YouTube
+ * extractor tweaks (player_client + PO Token), and the matched User-Agent.
+ */
+export function buildYtdlpCommonArgs(): string[] {
+  return [
+    "--no-playlist",
+    "--extractor-args",
+    `youtube:player_client=${YOUTUBE_PLAYER_CLIENTS}`,
+    "--extractor-args",
+    `youtubepot-bgutilhttp:base_url=${POT_PROVIDER_URL}`,
+    "--user-agent",
+    SAFARI_USER_AGENT,
+  ];
+}

--- a/src/lib/ytdlp-metadata.ts
+++ b/src/lib/ytdlp-metadata.ts
@@ -69,10 +69,25 @@ function normalizeYtdlpJson(raw: unknown): YtdlpMetadata {
   // a minor version bump could rename fields. Missing fields collapse to
   // safe defaults; type-unexpected values (e.g. `language: 42`) also
   // collapse, keeping the caller's contract simple.
-  const obj = (raw && typeof raw === "object" ? raw : {}) as Record<
-    string,
-    unknown
-  >;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("yt-dlp metadata returned a non-object payload");
+  }
+  const obj = raw as Record<string, unknown>;
+
+  // Every real yt-dlp video-info payload carries at least one of these
+  // anchor fields. `{}` (schema regression, partial response, wrong
+  // endpoint) would otherwise collapse to all-defaults and flow through
+  // as a silent success — the route would return 200 with garbage and
+  // the orchestrator would pin an arbitrary language to whisper.
+  const ANCHORS = ["id", "title", "webpage_url", "duration", "uploader"] as const;
+  const hasAnchor = ANCHORS.some(
+    (k) => obj[k] !== undefined && obj[k] !== null
+  );
+  if (!hasAnchor) {
+    throw new Error(
+      "yt-dlp metadata payload is missing all anchor fields — likely a schema regression"
+    );
+  }
 
   const title = typeof obj.title === "string" ? obj.title : "";
   const description =

--- a/src/lib/ytdlp-metadata.ts
+++ b/src/lib/ytdlp-metadata.ts
@@ -1,0 +1,114 @@
+import { execFile } from "child_process";
+import { buildYtdlpCommonArgs } from "./ytdlp-common.js";
+import type { YtdlpMetadata } from "./language-detect.js";
+
+// Descriptions are unbounded user content. Truncate before returning so we
+// don't bloat JSON responses or log lines. 2000 chars is more than enough
+// for language detection (franc's trigram model saturates around ~200
+// chars) and fits comfortably in a debug log.
+const DESCRIPTION_CHAR_CAP = 2000;
+
+// Metadata extraction is fast compared to audio download (no byte
+// streaming), but the player-response fetch can still stall on a slow
+// backend. 30s is generous without letting a stuck yt-dlp hold up the
+// request indefinitely.
+const YTDLP_METADATA_TIMEOUT_MS = 30_000;
+
+/**
+ * Build the argv for a yt-dlp metadata-only invocation. Reuses the same
+ * player_client / PO Token / UA profile as the audio download so a
+ * successful download implies a successful metadata fetch (and vice versa).
+ */
+export function buildYtdlpMetadataArgs(url: string): string[] {
+  return [
+    "--dump-json",
+    "--skip-download",
+    ...buildYtdlpCommonArgs(),
+    url,
+  ];
+}
+
+/**
+ * Invoke yt-dlp to dump the video's metadata JSON, parse, and normalize.
+ * Throws on non-zero exit or JSON parse failure — the caller's route
+ * should classify this as 500 so a persistent yt-dlp regression is
+ * visible rather than silently collapsing to "no language signal".
+ */
+export async function fetchYtdlpMetadata(url: string): Promise<YtdlpMetadata> {
+  const args = buildYtdlpMetadataArgs(url);
+
+  const stdout = await new Promise<string>((resolve, reject) => {
+    execFile(
+      "yt-dlp",
+      args,
+      { timeout: YTDLP_METADATA_TIMEOUT_MS, maxBuffer: 20 * 1024 * 1024 },
+      (error, out, stderr) => {
+        if (error) {
+          reject(new Error(`yt-dlp metadata failed: ${stderr || error.message}`));
+          return;
+        }
+        resolve(out);
+      }
+    );
+  });
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(stdout);
+  } catch (err) {
+    throw new Error(
+      `yt-dlp metadata returned invalid JSON: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
+  return normalizeYtdlpJson(raw);
+}
+
+function normalizeYtdlpJson(raw: unknown): YtdlpMetadata {
+  // Narrow to Record before field access — yt-dlp output is schema-drift-y;
+  // a minor version bump could rename fields. Missing fields collapse to
+  // safe defaults; type-unexpected values (e.g. `language: 42`) also
+  // collapse, keeping the caller's contract simple.
+  const obj = (raw && typeof raw === "object" ? raw : {}) as Record<
+    string,
+    unknown
+  >;
+
+  const title = typeof obj.title === "string" ? obj.title : "";
+  const description =
+    typeof obj.description === "string"
+      ? obj.description.slice(0, DESCRIPTION_CHAR_CAP)
+      : "";
+  const language =
+    typeof obj.language === "string" && obj.language.length > 0
+      ? obj.language
+      : null;
+
+  return {
+    title,
+    description,
+    language,
+    subtitles: normalizeCaptionDict(obj.subtitles),
+    automatic_captions: normalizeCaptionDict(obj.automatic_captions),
+  };
+}
+
+function normalizeCaptionDict(
+  raw: unknown
+): Readonly<Record<string, readonly { url: string; ext: string }[]>> {
+  if (!raw || typeof raw !== "object") return {};
+  const result: Record<string, { url: string; ext: string }[]> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(value)) continue;
+    const tracks = value
+      .filter(
+        (t): t is { url?: unknown; ext?: unknown } => t !== null && typeof t === "object"
+      )
+      .map((t) => ({
+        url: typeof t.url === "string" ? t.url : "",
+        ext: typeof t.ext === "string" ? t.ext : "",
+      }));
+    if (tracks.length > 0) result[key] = tracks;
+  }
+  return result;
+}

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -3,26 +3,9 @@ import { randomUUID } from "crypto";
 import { stat, unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
+import { buildYtdlpCommonArgs } from "./ytdlp-common.js";
 
-// Datacenter IPs frequently hit YouTube's "Sign in to confirm you're not a
-// bot" wall when yt-dlp uses the default `web` player client. Cycling
-// through alternate clients (mweb / web_safari / android_vr) unblocks most
-// requests when combined with a residential-IP egress path (Tailscale exit
-// node → home device, wired in docker-compose.yml).
-const YOUTUBE_PLAYER_CLIENTS = "web_safari,mweb,android_vr";
-
-// Pair the client list with a browser UA so the request profile matches.
-const SAFARI_USER_AGENT =
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
-
-// Proof-of-Origin Token provider. `pot-provider` is the sibling container
-// (see docker-compose.yml) that shares our network namespace, so it's
-// reachable on localhost. YouTube enforces PO Tokens across multiple
-// extraction paths — without this, requests fail regardless of IP
-// reputation or cookie state. Override via env for local dev or if the
-// sidecar's bind address changes.
-export const POT_PROVIDER_URL =
-  process.env.POT_PROVIDER_URL ?? "http://127.0.0.1:4416";
+export { POT_PROVIDER_URL } from "./ytdlp-common.js";
 
 export function buildYtdlpArgs(url: string, outputPath: string): string[] {
   return [
@@ -31,13 +14,7 @@ export function buildYtdlpArgs(url: string, outputPath: string): string[] {
     "mp3",
     "--audio-quality",
     "0",
-    "--no-playlist",
-    "--extractor-args",
-    `youtube:player_client=${YOUTUBE_PLAYER_CLIENTS}`,
-    "--extractor-args",
-    `youtubepot-bgutilhttp:base_url=${POT_PROVIDER_URL}`,
-    "--user-agent",
-    SAFARI_USER_AGENT,
+    ...buildYtdlpCommonArgs(),
     "-o",
     outputPath,
     url,

--- a/src/routes/__tests__/captions.test.ts
+++ b/src/routes/__tests__/captions.test.ts
@@ -134,6 +134,42 @@ describe("POST /captions", () => {
     // filter was applied.
     expect(spy).toHaveBeenCalledWith(expect.any(String), undefined);
   });
+
+  it.each([
+    ["--model", "CLI-flag shape"],
+    ["; rm -rf /", "shell-metachar shape"],
+    ["en_US", "underscore instead of dash"],
+    ["a", "too short"],
+    ["", "empty string"],
+    [" en", "leading whitespace"],
+  ])("rejects lang=%s (%s) with 400", async (lang) => {
+    // Argv-based execFile blocks shell injection, but a lang like "--model"
+    // would reach whisper and produce confusing CLI errors that surface
+    // as 500 in logs. Reject at the schema boundary so the failure is
+    // classified as "bad client input" instead of "service broken".
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      lang,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it.each([
+    ["en"],
+    ["fr"],
+    ["zh"],
+    ["eng"], // 3-letter ISO 639-3
+    ["en-US"],
+    ["zh-Hans"],
+    ["zh-Hant-TW"],
+  ])("accepts well-formed BCP-47 / ISO 639 tag: %s", async (lang) => {
+    vi.spyOn(captionsLib, "fetchCaptions").mockResolvedValue(null);
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      lang,
+    });
+    expect(res.status).toBe(404); // no_captions, but schema passed
+  });
 });
 
 describe("POST /captions — auth enforcement", () => {

--- a/src/routes/__tests__/captions.test.ts
+++ b/src/routes/__tests__/captions.test.ts
@@ -108,6 +108,32 @@ describe("POST /captions", () => {
     });
     expect(res.status).toBe(500);
   });
+
+  it("forwards `lang` to fetchCaptions when provided", async () => {
+    // Validates the critical handoff: without this, lang is accepted by
+    // the zod schema but silently dropped before reaching the library,
+    // leaving the `tracks[0]` bug unfixed.
+    const spy = vi
+      .spyOn(captionsLib, "fetchCaptions")
+      .mockResolvedValue(null);
+    await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      lang: "fr",
+    });
+    expect(spy).toHaveBeenCalledWith(expect.any(String), "fr");
+  });
+
+  it("omits `lang` when the caller didn't send one (back-compat)", async () => {
+    const spy = vi
+      .spyOn(captionsLib, "fetchCaptions")
+      .mockResolvedValue(null);
+    await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    // Second arg is undefined — preserves pre-PR behavior where no lang
+    // filter was applied.
+    expect(spy).toHaveBeenCalledWith(expect.any(String), undefined);
+  });
 });
 
 describe("POST /captions — auth enforcement", () => {

--- a/src/routes/__tests__/metadata.test.ts
+++ b/src/routes/__tests__/metadata.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { metadata } from "../metadata.js";
+import * as ytdlpMetadataLib from "../../lib/ytdlp-metadata.js";
+
+const VALID_KEY = "test-key";
+
+function post(body: unknown) {
+  return metadata.request("/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${VALID_KEY}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /metadata", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.VPS_API_KEY = VALID_KEY;
+  });
+
+  it("rejects malformed bodies with 400", async () => {
+    const res = await post({ not_the_right_field: "x" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-YouTube URLs with 400", async () => {
+    const res = await post({ youtube_url: "https://example.com/video" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects malformed JSON with 400 (not 500)", async () => {
+    const res = await metadata.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${VALID_KEY}`,
+      },
+      body: "{not valid json",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with language, title, description, availableCaptions on happy path", async () => {
+    vi.spyOn(ytdlpMetadataLib, "fetchYtdlpMetadata").mockResolvedValue({
+      title: "Comment apprendre",
+      description: "Une vidéo en français",
+      language: "fr",
+      subtitles: {},
+      automatic_captions: { fr: [{ url: "x", ext: "vtt" }], en: [{ url: "x", ext: "vtt" }] },
+    });
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.language).toBe("fr");
+    expect(body.title).toBe("Comment apprendre");
+    expect(body.description).toBe("Une vidéo en français");
+    expect(body.availableCaptions).toEqual(expect.arrayContaining(["fr", "en"]));
+  });
+
+  it("returns 500 with a generic message when yt-dlp throws", async () => {
+    // Internal stderr (paths, binary names, extractor internals) must not
+    // leak to the client — same contract as /captions and /transcribe.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(ytdlpMetadataLib, "fetchYtdlpMetadata").mockRejectedValue(
+      new Error("yt-dlp metadata failed: /opt/tmp/internal/path/leaked")
+    );
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Metadata fetch failed" });
+    expect(JSON.stringify(body)).not.toContain("/opt/tmp");
+  });
+});
+
+describe("POST /metadata — auth enforcement", () => {
+  beforeEach(() => {
+    process.env.VPS_API_KEY = VALID_KEY;
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without an Authorization header", async () => {
+    const res = await metadata.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 on a wrong bearer token", async () => {
+    const res = await metadata.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer wrong-key",
+      },
+      body: JSON.stringify({
+        youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { transcribe } from "../transcribe.js";
+import * as ytdlpLib from "../../lib/ytdlp.js";
+import * as whisperLib from "../../lib/whisper.js";
+
+const VALID_KEY = "test-key";
+
+function post(body: unknown) {
+  return transcribe.request("/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${VALID_KEY}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /transcribe", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.VPS_API_KEY = VALID_KEY;
+    vi.spyOn(ytdlpLib, "downloadAudio").mockResolvedValue("/tmp/fake.mp3");
+    vi.spyOn(ytdlpLib, "cleanupAudio").mockResolvedValue(undefined);
+  });
+
+  it("rejects malformed bodies with 400", async () => {
+    const res = await post({ not_the_right_field: "x" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-YouTube URLs with 400", async () => {
+    const res = await post({ youtube_url: "https://example.com/video" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with language='auto' when no lang provided (back-compat)", async () => {
+    // Pre-PR clients send `{youtube_url}` only and expect `language: "auto"`
+    // in the response. Preserve that exact shape.
+    vi.spyOn(whisperLib, "transcribeAudio").mockResolvedValue("hello world");
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      transcript: "hello world",
+      language: "auto",
+      source: "whisper",
+    });
+  });
+
+  it("forwards `lang` to transcribeAudio and echoes it in the response", async () => {
+    // Validates the handoff: a lang accepted by the zod schema must
+    // actually reach whisper. Without this check, the flag could be
+    // silently dropped and whisper would keep auto-detecting.
+    const spy = vi
+      .spyOn(whisperLib, "transcribeAudio")
+      .mockResolvedValue("bonjour");
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      lang: "fr",
+    });
+    expect(res.status).toBe(200);
+    expect(spy).toHaveBeenCalledWith("/tmp/fake.mp3", "fr");
+    const body = await res.json();
+    expect(body.language).toBe("fr");
+  });
+
+  it("returns 500 when yt-dlp download fails (no language echoed, no transcript leak)", async () => {
+    // Real yt-dlp stderr includes tmp paths and extractor internals; make
+    // sure none of it escapes into the response body.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(ytdlpLib, "downloadAudio").mockRejectedValue(
+      new Error("yt-dlp failed: /opt/tmp/internal-path /tmp/leak.mp3")
+    );
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Transcription failed" });
+    expect(JSON.stringify(body)).not.toContain("/opt/tmp");
+  });
+
+  it("returns 500 when whisper fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(whisperLib, "transcribeAudio").mockRejectedValue(
+      new Error("whisper crash")
+    );
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /transcribe — auth enforcement", () => {
+  beforeEach(() => {
+    process.env.VPS_API_KEY = VALID_KEY;
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without an Authorization header", async () => {
+    const res = await transcribe.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 on a wrong bearer token", async () => {
+    const res = await transcribe.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer wrong-key",
+      },
+      body: JSON.stringify({
+        youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -99,15 +99,22 @@ describe("POST /transcribe", () => {
     expect(JSON.stringify(body)).not.toContain("/opt/tmp");
   });
 
-  it("returns 500 when whisper fails", async () => {
+  it("returns 500 with generic body when whisper fails (no internal leak)", async () => {
+    // Generic body contract: a whisper-internal message must not reach
+    // the client. A regression returning `{ error: err.message }` would
+    // leak whisper/CTranslate2 internals.
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(whisperLib, "transcribeAudio").mockRejectedValue(
-      new Error("whisper crash")
+      new Error("whisper internal crash: /opt/models/tiny.bin missing")
     );
     const res = await post({
       youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
     });
     expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Transcription failed" });
+    expect(JSON.stringify(body)).not.toContain("whisper internal crash");
+    expect(JSON.stringify(body)).not.toContain("/opt/models");
   });
 });
 

--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -34,6 +34,23 @@ describe("POST /transcribe", () => {
     expect(res.status).toBe(400);
   });
 
+  it.each([
+    ["--language", "CLI-flag shape"],
+    ["; rm -rf /", "shell metachar shape"],
+    [" en", "leading whitespace"],
+    ["a", "too short"],
+    ["", "empty string"],
+  ])("rejects lang=%s (%s) with 400", async (lang) => {
+    // Schema-boundary rejection keeps garbage out of whisper's argv so
+    // a lang like "--model" can't produce a confusing 500 error deep
+    // in the CLI layer.
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      lang,
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("returns 200 with language='auto' when no lang provided (back-compat)", async () => {
     // Pre-PR clients send `{youtube_url}` only and expect `language: "auto"`
     // in the response. Preserve that exact shape.

--- a/src/routes/captions.ts
+++ b/src/routes/captions.ts
@@ -16,6 +16,11 @@ captions.use("*", authMiddleware);
 
 const requestSchema = z.object({
   youtube_url: youtubeUrlSchema,
+  // Optional ISO 639-1 or BCP-47 code. Passed through to
+  // `youtube-transcript-plus` so the library selects a specific caption
+  // track instead of the arbitrarily-ordered `tracks[0]`. Length cap is
+  // generous for BCP-47 (`zh-Hans`, `zh-Hant-TW`).
+  lang: z.string().min(2).max(16).optional(),
 });
 
 captions.post("/", async (c) => {
@@ -37,7 +42,7 @@ captions.post("/", async (c) => {
     );
   }
 
-  const { youtube_url } = parsed.data;
+  const { youtube_url, lang } = parsed.data;
 
   // Log only the videoId, never the full URL. YouTube URLs are unlikely
   // to contain secrets in practice, but the zod schema above only
@@ -46,8 +51,8 @@ captions.post("/", async (c) => {
   const videoId = extractVideoId(youtube_url) ?? "unknown";
 
   try {
-    console.log(`Fetching captions for video ${videoId}`);
-    const result = await fetchCaptions(youtube_url);
+    console.log(`Fetching captions for video ${videoId}${lang ? ` (lang=${lang})` : ""}`);
+    const result = await fetchCaptions(youtube_url, lang);
 
     // Status contract this route owes its consumers:
     //   200 — captions extracted, fallback path not needed

--- a/src/routes/captions.ts
+++ b/src/routes/captions.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { fetchCaptions, extractVideoId } from "../lib/captions.js";
-import { youtubeUrlSchema } from "../lib/youtube-url.js";
+import { languageCodeSchema, youtubeUrlSchema } from "../lib/youtube-url.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 const captions = new Hono();
@@ -18,9 +18,10 @@ const requestSchema = z.object({
   youtube_url: youtubeUrlSchema,
   // Optional ISO 639-1 or BCP-47 code. Passed through to
   // `youtube-transcript-plus` so the library selects a specific caption
-  // track instead of the arbitrarily-ordered `tracks[0]`. Length cap is
-  // generous for BCP-47 (`zh-Hans`, `zh-Hant-TW`).
-  lang: z.string().min(2).max(16).optional(),
+  // track instead of the arbitrarily-ordered `tracks[0]`. Regex-constrained
+  // at the schema boundary so values like `--help` or `"; rm -rf /"` are
+  // rejected here instead of producing confusing downstream CLI errors.
+  lang: languageCodeSchema.optional(),
 });
 
 captions.post("/", async (c) => {

--- a/src/routes/metadata.ts
+++ b/src/routes/metadata.ts
@@ -1,0 +1,64 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { fetchYtdlpMetadata } from "../lib/ytdlp-metadata.js";
+import {
+  detectLanguage,
+  extractAvailableCaptions,
+} from "../lib/language-detect.js";
+import { extractVideoId } from "../lib/captions.js";
+import { youtubeUrlSchema } from "../lib/youtube-url.js";
+import { authMiddleware } from "../middleware/auth.js";
+
+const metadata = new Hono();
+
+// Auth middleware attached inside the sub-router — same pattern as
+// /captions and /transcribe. See those routes for the reasoning.
+metadata.use("*", authMiddleware);
+
+const requestSchema = z.object({
+  youtube_url: youtubeUrlSchema,
+});
+
+metadata.post("/", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    // Explicit 400 so malformed bodies are client errors, not 500s. Same
+    // convention as /captions and /transcribe.
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const parsed = requestSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "Invalid request", details: parsed.error.flatten() },
+      400
+    );
+  }
+
+  const { youtube_url } = parsed.data;
+  const videoId = extractVideoId(youtube_url) ?? "unknown";
+
+  try {
+    console.log(`Fetching metadata for video ${videoId}`);
+    const ytdlpMeta = await fetchYtdlpMetadata(youtube_url);
+    const language = detectLanguage(ytdlpMeta);
+    const availableCaptions = extractAvailableCaptions(ytdlpMeta);
+
+    return c.json({
+      language,
+      title: ytdlpMeta.title,
+      description: ytdlpMeta.description,
+      availableCaptions,
+    });
+  } catch (err) {
+    // Generic client-facing message; full yt-dlp stderr stays in server
+    // logs. Mirrors the /transcribe and /captions error-handling shape.
+    const message = err instanceof Error ? err.message : "Metadata fetch failed";
+    console.error(`Metadata fetch error for video ${videoId}: ${message}`);
+    return c.json({ error: "Metadata fetch failed" }, 500);
+  }
+});
+
+export { metadata };

--- a/src/routes/transcribe.ts
+++ b/src/routes/transcribe.ts
@@ -16,6 +16,10 @@ transcribe.use("*", authMiddleware);
 
 const requestSchema = z.object({
   youtube_url: youtubeUrlSchema,
+  // Optional ISO 639-1 code. When present, forwarded to whisper as
+  // `--language <code>` so the model transcribes into the named language
+  // instead of auto-detecting (which misfires on short/noisy clips).
+  lang: z.string().min(2).max(16).optional(),
 });
 
 transcribe.post("/", async (c) => {
@@ -37,22 +41,27 @@ transcribe.post("/", async (c) => {
     );
   }
 
-  const { youtube_url } = parsed.data;
+  const { youtube_url, lang } = parsed.data;
   const videoId = extractVideoId(youtube_url) ?? "unknown";
   let audioPath: string | null = null;
 
   try {
-    console.log(`Transcribing video ${videoId}`);
+    console.log(
+      `Transcribing video ${videoId}${lang ? ` (lang=${lang})` : ""}`
+    );
 
     audioPath = await downloadAudio(youtube_url);
     console.log(`Audio downloaded to: ${audioPath}`);
 
-    const transcript = await transcribeAudio(audioPath);
+    const transcript = await transcribeAudio(audioPath, lang);
     console.log(`Transcription complete: ${transcript.length} characters`);
 
     return c.json({
       transcript,
-      language: "auto",
+      // Echo back what we pinned so callers know which language we
+      // instructed whisper to produce. "auto" preserves the prior contract
+      // when no hint was provided.
+      language: lang ?? "auto",
       source: "whisper" as const,
     });
   } catch (err) {

--- a/src/routes/transcribe.ts
+++ b/src/routes/transcribe.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { downloadAudio, cleanupAudio } from "../lib/ytdlp.js";
 import { transcribeAudio } from "../lib/whisper.js";
 import { extractVideoId } from "../lib/captions.js";
-import { youtubeUrlSchema } from "../lib/youtube-url.js";
+import { languageCodeSchema, youtubeUrlSchema } from "../lib/youtube-url.js";
 import { authMiddleware } from "../middleware/auth.js";
 
 const transcribe = new Hono();
@@ -19,7 +19,9 @@ const requestSchema = z.object({
   // Optional ISO 639-1 code. When present, forwarded to whisper as
   // `--language <code>` so the model transcribes into the named language
   // instead of auto-detecting (which misfires on short/noisy clips).
-  lang: z.string().min(2).max(16).optional(),
+  // Regex-constrained at the schema boundary so values like `--model` or
+  // `"; rm -rf /"` are rejected here instead of polluting whisper's argv.
+  lang: languageCodeSchema.optional(),
 });
 
 transcribe.post("/", async (c) => {


### PR DESCRIPTION
## Summary

- New `POST /metadata` endpoint extracts title, description, detected language, and available caption language codes via `yt-dlp --dump-json`. Uses `franc` as a text-detection fallback when yt-dlp's explicit `language` field is absent.
- `POST /captions` and `POST /transcribe` now accept an optional `lang` param that forwards to `fetchTranscript({ lang })` and `whisper-ctranslate2 --language <code>` respectively. Omitting `lang` preserves the previous behavior.
- Extracted the shared yt-dlp player_client / UA / PO-Token args into `ytdlp-common.ts` so audio-download and metadata-fetch paths can't drift out of sync on a future tweak.

## Why

A French video (`https://www.youtube.com/watch?v=8MopJoonTt0`) produced an Arabic transcript in production. Root cause: `youtube-transcript-plus` at `dist/index.js:279-281` grabs `tracks[0]` when no `lang` is provided, and YouTube's caption track ordering doesn't correlate with audio language. Whisper fallback had the same class of issue — no `--language` hint, so auto-detect could misfire on short/noisy clips.

Design doc: `docs/superpowers/specs/2026-04-21-video-language-detection-design.md` (in the parent workspace).

## Test plan

- [x] All existing tests pass unchanged (back-compat for `lang`-less calls)
- [x] `npm test` — 141 tests passing (up from 95)
- [x] `npx tsc --noEmit` clean
- [ ] Post-deploy smoke: `POST /metadata` against the bug video returns `language: "fr"` or similar
- [ ] Post-deploy smoke: `POST /captions` with `lang=fr` returns a French transcript (not Arabic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)