### PR TITLE
feat: emit timestamped segments from caption + whisper paths

### DIFF
--- a/src/lib/__tests__/captions.test.ts
+++ b/src/lib/__tests__/captions.test.ts
@@ -283,6 +283,26 @@ describe("fetchCaptions", () => {
     expect(call[1]).not.toHaveProperty("lang");
   });
 
+  it("calls pickLocale with the RAW library segments, not the mapped {start,duration,text} ones", async () => {
+    // Subtle invariant: `pickLocale` reads `segments[0].lang` to pick the
+    // prompt template. Our mapped `TranscriptSegment` shape doesn't carry
+    // a `lang` field — only the raw library segments do. A "tidy this up"
+    // refactor that swapped `pickLocale(ytSegments, ...)` to
+    // `pickLocale(segments, ...)` would silently route every Chinese
+    // video to the English prompt. Pin the contract via a happy-path
+    // assertion that depends on lang resolution working through.
+    mockedFetchTranscript.mockResolvedValue(
+      ok([{ text: "你好", lang: "zh-CN", offset: 0, duration: 1 }])
+    );
+    const result = await fetchCaptions("https://youtu.be/dQw4w9WgXcQ");
+    // language === "zh" can ONLY come from the raw `lang: "zh-CN"` field —
+    // mapped segments lack `lang` so pickLocale would default to "en".
+    expect(result?.language).toBe("zh");
+    // And the mapped segment carries no `lang` field — proves the two
+    // arrays are distinct.
+    expect(result?.segments[0]).not.toHaveProperty("lang");
+  });
+
   it("forwards `lang` to the library when provided (pins caption track)", async () => {
     // The whole point of this parameter: without it, the library picks
     // `tracks[0]` which for some videos is the wrong language entirely.

--- a/src/lib/__tests__/captions.test.ts
+++ b/src/lib/__tests__/captions.test.ts
@@ -128,9 +128,17 @@ describe("fetchCaptions", () => {
   // but with `videoDetails: true` it actually returns a richer object that
   // production code casts. Match that runtime shape but cast to the
   // declared type so the mock satisfies TS.
+  //
+  // Each fixture segment ships with `offset` and `duration` because those
+  // flow into the response now — text-only fixtures would land in the
+  // assertion as start/duration=undefined and silently pass a NaN check.
   const ok = (segments: Partial<TranscriptSegment>[]) =>
     ({
-      segments,
+      segments: segments.map((s, i) => ({
+        offset: i,
+        duration: 1,
+        ...s,
+      })),
       videoDetails: { title: "t", author: "a" },
     } as unknown as TranscriptSegment[]);
 
@@ -213,19 +221,22 @@ describe("fetchCaptions", () => {
     );
   });
 
-  it("joins multi-segment transcripts and normalizes whitespace", async () => {
-    // Invariant: the joining pipeline (`join(" ") + collapse + trim`)
-    // must not produce double-spaces, leading/trailing whitespace, or
-    // preserve embedded \n\t runs. A refactor to `.join("\n")` would
-    // break this test.
+  it("preserves segment text verbatim and pairs each with its timing data", async () => {
+    // Segments are now the source of truth. The frontend renders them
+    // chunked into paragraphs at display time, so the lib must hand them
+    // through unmodified — a refactor that re-introduced whitespace
+    // collapse here would silently corrupt the text the LLM sees.
     mockedFetchTranscript.mockResolvedValue(
       ok([
-        { text: "  hello\tworld  ", lang: "en" },
-        { text: "\n\n  foo  ", lang: "en" },
+        { text: "  hello\tworld  ", lang: "en", offset: 0, duration: 2 },
+        { text: "foo", lang: "en", offset: 2, duration: 1.5 },
       ])
     );
     const result = await fetchCaptions("https://youtu.be/dQw4w9WgXcQ");
-    expect(result?.transcript).toBe("hello world foo");
+    expect(result?.segments).toEqual([
+      { text: "  hello\tworld  ", start: 0, duration: 2 },
+      { text: "foo", start: 2, duration: 1.5 },
+    ]);
   });
 
   it("returns null metadata fields when videoDetails is undefined (not empty string)", async () => {
@@ -243,13 +254,16 @@ describe("fetchCaptions", () => {
   it("maps the full happy path to a CaptionResult", async () => {
     mockedFetchTranscript.mockResolvedValue(
       ok([
-        { text: "hello", lang: "zh-CN" },
-        { text: "world", lang: "zh-CN" },
+        { text: "hello", lang: "zh-CN", offset: 0, duration: 1 },
+        { text: "world", lang: "zh-CN", offset: 1, duration: 2 },
       ])
     );
     const result = await fetchCaptions("https://youtu.be/dQw4w9WgXcQ");
     expect(result).toEqual({
-      transcript: "hello world",
+      segments: [
+        { text: "hello", start: 0, duration: 1 },
+        { text: "world", start: 1, duration: 2 },
+      ],
       source: "auto_captions",
       language: "zh",
       title: "t",

--- a/src/lib/__tests__/whisper.test.ts
+++ b/src/lib/__tests__/whisper.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildWhisperArgs, WHISPER_CLI } from "../whisper.js";
+import { buildWhisperArgs, parseWhisperJson, WHISPER_CLI } from "../whisper.js";
 
 describe("buildWhisperArgs", () => {
   it("builds correct whisper-ctranslate2 arguments", () => {
@@ -8,7 +8,7 @@ describe("buildWhisperArgs", () => {
     expect(args).toContain("--model");
     expect(args).toContain("tiny");
     expect(args).toContain("--output_format");
-    expect(args).toContain("txt");
+    expect(args).toContain("json");
   });
 
   // The constant itself is pinned in a brittle way — renaming the export
@@ -33,7 +33,10 @@ describe("buildWhisperArgs", () => {
     }
     expect(flagPairs["--compute_type"]).toBe("int8");
     expect(flagPairs["--vad_filter"]).toBe("True");
-    expect(flagPairs["--output_format"]).toBe("txt");
+    // json output preserves per-segment timing the frontend uses to
+    // render clickable timestamps. A regression to txt would silently
+    // strip timing data — this guard catches that drift.
+    expect(flagPairs["--output_format"]).toBe("json");
     expect(flagPairs["--beam_size"]).toBe("1");
   });
 
@@ -58,5 +61,57 @@ describe("buildWhisperArgs", () => {
     const args = buildWhisperArgs("/tmp/audio.mp3", "zh");
     const langIdx = args.indexOf("--language");
     expect(args[langIdx + 1]).toBe("zh");
+  });
+});
+
+describe("parseWhisperJson", () => {
+  it("maps whisper segments to {text,start,duration} and computes duration from end-start", () => {
+    const json = JSON.stringify({
+      segments: [
+        { id: 0, start: 0.0, end: 2.5, text: "Hello world" },
+        { id: 1, start: 2.5, end: 5.0, text: "How are you" },
+      ],
+    });
+    expect(parseWhisperJson(json)).toEqual([
+      { text: "Hello world", start: 0.0, duration: 2.5 },
+      { text: "How are you", start: 2.5, duration: 2.5 },
+    ]);
+  });
+
+  it("trims whitespace and drops segments with empty text", () => {
+    // whisper-ctranslate2 sometimes prefixes a leading space and emits a
+    // trailing empty segment for end-of-audio silence. The frontend would
+    // render that as a phantom 00:00 paragraph if it slipped through.
+    const json = JSON.stringify({
+      segments: [
+        { start: 0, end: 1, text: " hello " },
+        { start: 1, end: 2, text: "" },
+        { start: 2, end: 3, text: "   " },
+      ],
+    });
+    expect(parseWhisperJson(json)).toEqual([
+      { text: "hello", start: 0, duration: 1 },
+    ]);
+  });
+
+  it("throws on malformed JSON (a non-fatal fall-through would silently bill GPU)", () => {
+    expect(() => parseWhisperJson("not json")).toThrow(/JSON parse failed/);
+  });
+
+  it("throws when the segments array is missing (catches CLI version drift)", () => {
+    // A faster-whisper-ctranslate2 upgrade that changed the JSON shape
+    // would break this contract — we want a loud failure, not a silent
+    // empty transcript.
+    expect(() => parseWhisperJson(JSON.stringify({ language: "en" }))).toThrow(
+      /missing `segments` array/
+    );
+  });
+
+  it("throws when a segment is missing required fields", () => {
+    expect(() =>
+      parseWhisperJson(
+        JSON.stringify({ segments: [{ start: 0, text: "hi" }] })
+      )
+    ).toThrow(/missing start\/end\/text/);
   });
 });

--- a/src/lib/captions.ts
+++ b/src/lib/captions.ts
@@ -6,7 +6,7 @@ import {
   YoutubeTranscriptNotAvailableLanguageError,
   YoutubeTranscriptVideoUnavailableError,
   type TranscriptResult,
-  type TranscriptSegment,
+  type TranscriptSegment as YtTranscriptSegment,
 } from "youtube-transcript-plus";
 
 // Caption fetching must run from an IP YouTube classifies as residential —
@@ -17,8 +17,21 @@ import {
 
 export type PromptLocale = "en" | "zh";
 
+/**
+ * One transcript line with its playback timing. The frontend uses these to
+ * render clickable timestamps that seek the embedded YouTube player.
+ *
+ * Same shape is produced by the Whisper fallback so consumers don't need to
+ * branch on transcript source.
+ */
+export interface TranscriptSegment {
+  readonly text: string;
+  readonly start: number; // seconds from start of video
+  readonly duration: number; // seconds
+}
+
 export interface CaptionResult {
-  readonly transcript: string;
+  readonly segments: readonly TranscriptSegment[];
   readonly source: "auto_captions";
   readonly language: PromptLocale;
   // `null` not `""`: the distinction between "YouTube returned empty" and
@@ -69,7 +82,7 @@ export function isExpectedNoCaptions(err: unknown): boolean {
 // the only prompt template guaranteed to exist; the warning is so we can
 // audit miss rate and decide whether to add ja/ko/etc.
 export function pickLocale(
-  segments: readonly TranscriptSegment[],
+  segments: readonly YtTranscriptSegment[],
   videoId?: string
 ): PromptLocale {
   const lang = segments[0]?.lang ?? "";
@@ -122,8 +135,8 @@ export async function fetchCaptions(
     throw err;
   }
 
-  const { segments, videoDetails } = result;
-  if (!segments || segments.length === 0) {
+  const { segments: ytSegments, videoDetails } = result;
+  if (!ytSegments || ytSegments.length === 0) {
     // Library reported success but handed back no segments. Usually this
     // means the video genuinely has no captions, but a YouTube schema
     // shift ("segments array now lives under .tracks") could hit this
@@ -136,27 +149,31 @@ export async function fetchCaptions(
     return null;
   }
 
-  const transcript = segments
-    .map((s) => s.text)
-    .join(" ")
-    .replace(/\s+/g, " ")
-    .trim();
+  // Keep only segments whose text contains visible characters. A track of
+  // pure-whitespace lines (music-cue videos) yields no useful transcript
+  // and should fall back to Whisper rather than persist an empty string
+  // through the pipeline.
+  const segments: TranscriptSegment[] = ytSegments
+    .filter((s) => s.text.trim().length > 0)
+    .map((s) => ({
+      text: s.text,
+      start: s.offset,
+      duration: s.duration,
+    }));
 
-  if (!transcript) {
-    // All segments were whitespace-only. Rare but real (music-cue
-    // videos). Log for the same reason as the empty-segments branch.
+  if (segments.length === 0) {
     console.warn("[captions] whitespace-only transcript, treating as no_captions", {
       errorId: "CAPTION_EMPTY_TRANSCRIPT",
       videoId,
-      segmentCount: segments.length,
+      segmentCount: ytSegments.length,
     });
     return null;
   }
 
   return {
-    transcript,
+    segments,
     source: "auto_captions",
-    language: pickLocale(segments, videoId),
+    language: pickLocale(ytSegments, videoId),
     title: videoDetails?.title ?? null,
     channelName: videoDetails?.author ?? null,
   };

--- a/src/lib/whisper.ts
+++ b/src/lib/whisper.ts
@@ -2,6 +2,7 @@ import { execFile } from "child_process";
 import { readFile, unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join, basename } from "path";
+import type { TranscriptSegment } from "./captions.js";
 
 export function buildWhisperArgs(audioPath: string, lang?: string): string[] {
   const args = [
@@ -16,8 +17,11 @@ export function buildWhisperArgs(audioPath: string, lang?: string): string[] {
     "1",
     "--vad_filter",
     "True",
+    // JSON output preserves per-segment timing the frontend uses to render
+    // clickable timestamps. Plain-text output dropped the timing data on
+    // the floor before the frontend ever saw it.
     "--output_format",
-    "txt",
+    "json",
     "--output_dir",
     tmpdir(),
   ];
@@ -40,17 +44,74 @@ export function buildWhisperArgs(audioPath: string, lang?: string): string[] {
 // yt-dlp path was fixed enough to actually reach this step.
 export const WHISPER_CLI = "whisper-ctranslate2";
 
+interface WhisperJsonSegment {
+  start: number;
+  end: number;
+  text: string;
+}
+
+interface WhisperJsonOutput {
+  segments: WhisperJsonSegment[];
+}
+
+/**
+ * Parse the JSON file written by `whisper-ctranslate2 --output_format json`
+ * into our segment shape. Drops empty segments (whisper sometimes emits a
+ * trailing `""` for end-of-audio silence) and trims surrounding whitespace
+ * the model occasionally leaves on segment text.
+ *
+ * Throws on schema mismatch — a silent fall-through to "no segments" would
+ * hide a faster-whisper-ctranslate2 upgrade that broke the JSON contract,
+ * billing GPU for transcripts the frontend then renders as a single 00:00
+ * legacy paragraph.
+ */
+export function parseWhisperJson(json: string): TranscriptSegment[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error(
+      `whisper JSON parse failed: ${err instanceof Error ? err.message : err}`
+    );
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    !Array.isArray((parsed as WhisperJsonOutput).segments)
+  ) {
+    throw new Error("whisper JSON missing `segments` array");
+  }
+  const raw = (parsed as WhisperJsonOutput).segments;
+  const out: TranscriptSegment[] = [];
+  for (const s of raw) {
+    if (
+      typeof s.start !== "number" ||
+      typeof s.end !== "number" ||
+      typeof s.text !== "string"
+    ) {
+      throw new Error("whisper JSON segment missing start/end/text");
+    }
+    const text = s.text.trim();
+    if (!text) continue;
+    out.push({ text, start: s.start, duration: s.end - s.start });
+  }
+  return out;
+}
+
 /**
  * Transcribe an audio file using the faster-whisper-backed CLI.
  * When `lang` is provided, whisper's auto-detect is bypassed and the
  * transcription is forced into the named language — used when the
  * orchestrator has a high-confidence signal (yt-dlp metadata) and wants
  * to avoid whisper misfiring on short/noisy audio.
+ *
+ * Returns timestamped segments — the frontend uses these to render
+ * clickable timestamps that seek the embedded YouTube player.
  */
 export async function transcribeAudio(
   audioPath: string,
   lang?: string
-): Promise<string> {
+): Promise<TranscriptSegment[]> {
   return new Promise((resolve, reject) => {
     const args = buildWhisperArgs(audioPath, lang);
 
@@ -64,21 +125,21 @@ export async function transcribeAudio(
           return;
         }
 
-        const txtPath = join(
+        const jsonPath = join(
           tmpdir(),
-          basename(audioPath).replace(/\.[^.]+$/, ".txt")
+          basename(audioPath).replace(/\.[^.]+$/, ".json")
         );
 
         try {
-          const transcript = await readFile(txtPath, "utf-8");
-          await unlink(txtPath).catch((unlinkErr) => {
+          const raw = await readFile(jsonPath, "utf-8");
+          await unlink(jsonPath).catch((unlinkErr) => {
             // Cleanup failure is non-fatal — the transcript is in-memory —
             // but a repeated EACCES/EBUSY is a leak signal worth surfacing.
             console.warn(
-              `[whisper] failed to unlink ${txtPath}: ${unlinkErr}`
+              `[whisper] failed to unlink ${jsonPath}: ${unlinkErr}`
             );
           });
-          resolve(transcript.trim());
+          resolve(parseWhisperJson(raw));
         } catch (readErr) {
           reject(new Error(`Failed to read transcript file: ${readErr}`));
         }

--- a/src/routes/__tests__/captions.test.ts
+++ b/src/routes/__tests__/captions.test.ts
@@ -61,9 +61,18 @@ describe("POST /captions", () => {
     expect(await res.json()).toEqual({ error: "no_captions" });
   });
 
-  it("returns 200 with the full caption result on success", async () => {
+  it("returns 200 with segments + a derived transcript string on success", async () => {
+    // Wire response includes both `segments` (canonical) and `transcript`
+    // (derived). The transcript field is kept for one rollout window so a
+    // frontend deployment that hasn't picked up segments yet still works;
+    // a follow-up cleanup PR drops it. Drift here would either break the
+    // old frontend (transcript missing) or stop carrying timing to the
+    // new frontend (segments missing).
     const mockResult = {
-      transcript: "hello world",
+      segments: [
+        { text: "hello", start: 0, duration: 1 },
+        { text: "world", start: 1, duration: 1 },
+      ],
       source: "auto_captions" as const,
       language: "en" as const,
       title: "test video",
@@ -74,7 +83,10 @@ describe("POST /captions", () => {
       youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
     });
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual(mockResult);
+    expect(await res.json()).toEqual({
+      ...mockResult,
+      transcript: "hello world",
+    });
   });
 
   it("returns 500 with a generic message when fetchCaptions throws", async () => {

--- a/src/routes/__tests__/captions.test.ts
+++ b/src/routes/__tests__/captions.test.ts
@@ -89,6 +89,29 @@ describe("POST /captions", () => {
     });
   });
 
+  it("normalizes whitespace in the derived transcript (matches pre-PR contract)", async () => {
+    // The pre-PR captions path joined and then `.replace(/\s+/g, " ").trim()`-ed
+    // the transcript. An old frontend that hashed / length-gated the field
+    // would otherwise see a different value for the same video during the
+    // rollout window. The route preserves the legacy normalization on the
+    // derived string while keeping the segments themselves verbatim.
+    vi.spyOn(captionsLib, "fetchCaptions").mockResolvedValue({
+      segments: [
+        { text: "  hello\tworld  ", start: 0, duration: 1 },
+        { text: "\n\n  foo  ", start: 1, duration: 1 },
+      ],
+      source: "auto_captions" as const,
+      language: "en" as const,
+      title: "t",
+      channelName: "c",
+    });
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    const body = (await res.json()) as { transcript: string };
+    expect(body.transcript).toBe("hello world foo");
+  });
+
   it("returns 500 with a generic message when fetchCaptions throws", async () => {
     // Captions lib throws only on unexpected errors (library schema
     // drift, network, parse failure). We return a generic string to the

--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -51,15 +51,24 @@ describe("POST /transcribe", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 200 with language='auto' when no lang provided (back-compat)", async () => {
-    // Pre-PR clients send `{youtube_url}` only and expect `language: "auto"`
-    // in the response. Preserve that exact shape.
-    vi.spyOn(whisperLib, "transcribeAudio").mockResolvedValue("hello world");
+  it("returns 200 with segments + derived transcript and language='auto' when no lang (back-compat)", async () => {
+    // Wire response includes `segments` (canonical) and `transcript`
+    // (derived from segments). The transcript field is kept for one
+    // rollout window so a frontend that hasn't picked up segments yet
+    // still works.
+    vi.spyOn(whisperLib, "transcribeAudio").mockResolvedValue([
+      { text: "hello", start: 0, duration: 1 },
+      { text: "world", start: 1, duration: 1 },
+    ]);
     const res = await post({
       youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
+      segments: [
+        { text: "hello", start: 0, duration: 1 },
+        { text: "world", start: 1, duration: 1 },
+      ],
       transcript: "hello world",
       language: "auto",
       source: "whisper",
@@ -72,7 +81,7 @@ describe("POST /transcribe", () => {
     // silently dropped and whisper would keep auto-detecting.
     const spy = vi
       .spyOn(whisperLib, "transcribeAudio")
-      .mockResolvedValue("bonjour");
+      .mockResolvedValue([{ text: "bonjour", start: 0, duration: 1 }]);
     const res = await post({
       youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
       lang: "fr",

--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -108,6 +108,47 @@ describe("POST /transcribe", () => {
     expect(JSON.stringify(body)).not.toContain("/opt/tmp");
   });
 
+  it("normalizes whitespace in the derived transcript (matches pre-PR contract)", async () => {
+    // Mirror of the captions-route normalization test: the derived
+    // `transcript` field preserves the pre-PR `replace(/\s+/g, " ").trim()`
+    // normalization so an old frontend that hashed/length-gated the field
+    // sees the same byte sequence during the rollout window. Segments
+    // themselves stay verbatim — this is purely about the legacy alias.
+    vi.spyOn(whisperLib, "transcribeAudio").mockResolvedValue([
+      { text: "  hello\tworld  ", start: 0, duration: 1 },
+      { text: "\n\n  foo  ", start: 1, duration: 1 },
+    ]);
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    const body = (await res.json()) as { transcript: string };
+    expect(body.transcript).toBe("hello world foo");
+  });
+
+  it("returns 500 with WHISPER_EMPTY_RESULT when whisper produces zero usable segments", async () => {
+    // Symmetric of the captions path's CAPTION_EMPTY_TRANSCRIPT — silently
+    // shipping `transcript: ""` would let a VAD misconfig / yt-dlp
+    // encoding bug / model upgrade artifact land as a 200 success and
+    // produce a garbage LLM summary downstream. Surfacing as 500 routes
+    // it through the existing alert + skip-cache path.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(whisperLib, "transcribeAudio").mockResolvedValue([]);
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: "Transcription produced no content",
+    });
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("WHISPER_EMPTY_RESULT"),
+      expect.objectContaining({
+        errorId: "WHISPER_EMPTY_RESULT",
+        videoId: "dQw4w9WgXcQ",
+      })
+    );
+  });
+
   it("returns 500 with generic body when whisper fails (no internal leak)", async () => {
     // Generic body contract: a whisper-internal message must not reach
     // the client. A regression returning `{ error: err.message }` would

--- a/src/routes/captions.ts
+++ b/src/routes/captions.ts
@@ -68,9 +68,18 @@ captions.post("/", async (c) => {
     // rollout window so a frontend that hasn't deployed yet keeps
     // working). The follow-up cleanup PR drops `transcript` once the
     // frontend is fully migrated.
+    //
+    // The derived string preserves the pre-PR whitespace normalization
+    // (`join(" ").replace(/\s+/g, " ").trim()`). An old frontend that
+    // hashed/length-gated the transcript would otherwise see a
+    // different value for the same video during the rollout window.
     return c.json({
       ...result,
-      transcript: result.segments.map((s) => s.text).join(" "),
+      transcript: result.segments
+        .map((s) => s.text)
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .trim(),
     });
   } catch (err) {
     const message =

--- a/src/routes/captions.ts
+++ b/src/routes/captions.ts
@@ -63,7 +63,15 @@ captions.post("/", async (c) => {
     //         silently since that masks real problems behind compute bills)
     if (!result) return c.json({ error: "no_captions" }, 404);
 
-    return c.json(result);
+    // Wire response carries `segments` (the canonical shape consumed by
+    // the new frontend) AND a derived `transcript` string (kept for one
+    // rollout window so a frontend that hasn't deployed yet keeps
+    // working). The follow-up cleanup PR drops `transcript` once the
+    // frontend is fully migrated.
+    return c.json({
+      ...result,
+      transcript: result.segments.map((s) => s.text).join(" "),
+    });
   } catch (err) {
     const message =
       err instanceof Error ? err.message : "Caption fetch failed";

--- a/src/routes/transcribe.ts
+++ b/src/routes/transcribe.ts
@@ -55,11 +55,17 @@ transcribe.post("/", async (c) => {
     audioPath = await downloadAudio(youtube_url);
     console.log(`Audio downloaded to: ${audioPath}`);
 
-    const transcript = await transcribeAudio(audioPath, lang);
-    console.log(`Transcription complete: ${transcript.length} characters`);
+    const segments = await transcribeAudio(audioPath, lang);
+    console.log(`Transcription complete: ${segments.length} segments`);
 
+    // Wire response carries `segments` (the canonical shape consumed by
+    // the new frontend) AND a derived `transcript` string (kept for one
+    // rollout window so a frontend that hasn't deployed yet keeps
+    // working). The follow-up cleanup PR drops `transcript` once the
+    // frontend is fully migrated.
     return c.json({
-      transcript,
+      segments,
+      transcript: segments.map((s) => s.text).join(" "),
       // Echo back what we pinned so callers know which language we
       // instructed whisper to produce. "auto" preserves the prior contract
       // when no hint was provided.

--- a/src/routes/transcribe.ts
+++ b/src/routes/transcribe.ts
@@ -58,14 +58,36 @@ transcribe.post("/", async (c) => {
     const segments = await transcribeAudio(audioPath, lang);
     console.log(`Transcription complete: ${segments.length} segments`);
 
+    // Empty whisper output is the symmetric twin of the captions path's
+    // CAPTION_EMPTY_TRANSCRIPT case — silently shipping `transcript: ""`
+    // would let a VAD misconfiguration / yt-dlp encoding bug / model
+    // upgrade artifact land as success-shaped 200, then produce a garbage
+    // LLM summary downstream. Surface as 500 so the route's existing
+    // "alert and skip cache" path classifies it correctly.
+    if (segments.length === 0) {
+      console.error(`[transcribe] WHISPER_EMPTY_RESULT for video ${videoId}`, {
+        errorId: "WHISPER_EMPTY_RESULT",
+        videoId,
+      });
+      return c.json({ error: "Transcription produced no content" }, 500);
+    }
+
     // Wire response carries `segments` (the canonical shape consumed by
     // the new frontend) AND a derived `transcript` string (kept for one
     // rollout window so a frontend that hasn't deployed yet keeps
     // working). The follow-up cleanup PR drops `transcript` once the
     // frontend is fully migrated.
+    //
+    // The derived string preserves the pre-PR whitespace normalization
+    // (`join(" ").replace(/\s+/g, " ").trim()`) so an old frontend's
+    // text-hash / dedupe behaviour matches what it saw before.
     return c.json({
       segments,
-      transcript: segments.map((s) => s.text).join(" "),
+      transcript: segments
+        .map((s) => s.text)
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .trim(),
       // Echo back what we pinned so callers know which language we
       // instructed whisper to produce. "auto" preserves the prior contract
       // when no hint was provided.


### PR DESCRIPTION
## Summary

- Internal lib types switch from `transcript: string` to `segments: TranscriptSegment[]` so per-line playback timing flows from the captions API and Whisper through to the frontend.
- Whisper now emits JSON instead of plain text so per-segment timing survives the parse step.
- Wire response carries both `segments` (canonical) and a derived `transcript` string for one rollout window so a frontend that hasn't picked up segments yet keeps working. The follow-up cleanup PR drops the alias.

## Test plan
- [x] Unit tests pass (`npm test` — 174 tests)
- [x] `npm run build` clean
- [ ] Post-deploy: smoke test against live VPS confirms `/captions` and `/transcribe` return both fields
- [ ] Frontend PR (xtan9/youtubeai_chat_frontend#26) consumes segments — merge this first

See `docs/superpowers/specs/2026-04-24-clickable-transcript-timestamps-design.md` for the full design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)