### PR TITLE
fix(captions): decode double-encoded XML entities so transcripts read clean

### DIFF
--- a/src/lib/__tests__/captions.test.ts
+++ b/src/lib/__tests__/captions.test.ts
@@ -154,6 +154,38 @@ describe("decodeCaptionEntities", () => {
     // Non-ASCII passes through.
     expect(decodeCaptionEntities("café — naïve")).toBe("café — naïve");
   });
+
+  it("handles supplementary-plane codepoints (emoji, > 0xFFFF)", () => {
+    // U+1F600 GRINNING FACE = 128512
+    expect(decodeCaptionEntities("hi &#128512;!")).toBe("hi 😀!");
+    expect(decodeCaptionEntities("&#x1F600;")).toBe("😀");
+  });
+
+  it("does not throw on out-of-range numeric entities (returns original)", () => {
+    // > 0x10FFFF: String.fromCodePoint would throw RangeError. The
+    // decoder must return the raw entity unchanged so a single
+    // malformed entity can't 500 an entire captions fetch.
+    expect(() => decodeCaptionEntities("bad &#999999999999;")).not.toThrow();
+    expect(decodeCaptionEntities("bad &#999999999999;")).toBe(
+      "bad &#999999999999;"
+    );
+    expect(decodeCaptionEntities("bad &#xFFFFFFFF;")).toBe("bad &#xFFFFFFFF;");
+  });
+
+  it("preserves malformed entity-like substrings unchanged", () => {
+    // Missing semicolon, missing digits, named-but-unknown — all should
+    // pass through as-is rather than partial-match into garbage.
+    expect(decodeCaptionEntities("a &amp b")).toBe("a &amp b"); // no `;`
+    expect(decodeCaptionEntities("a &; b")).toBe("a &; b");
+    expect(decodeCaptionEntities("a &#; b")).toBe("a &#; b");
+    expect(decodeCaptionEntities("a &foo; b")).toBe("a &foo; b");
+  });
+
+  it("handles mixed entities in one string", () => {
+    expect(
+      decodeCaptionEntities("Tom &amp; &#39;Jerry&#39; &#x2014; fin")
+    ).toBe("Tom & 'Jerry' — fin");
+  });
 });
 
 describe("fetchCaptions", () => {

--- a/src/lib/__tests__/captions.test.ts
+++ b/src/lib/__tests__/captions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
+  decodeCaptionEntities,
   extractVideoId,
   fetchCaptions,
   isExpectedNoCaptions,
@@ -116,6 +117,42 @@ describe("pickLocale", () => {
 
   it("falls back to en when segments array is empty", () => {
     expect(pickLocale([])).toBe("en");
+  });
+});
+
+describe("decodeCaptionEntities", () => {
+  it("decodes the named XML entities the library already handles once", () => {
+    expect(decodeCaptionEntities("Tom &amp; Jerry")).toBe("Tom & Jerry");
+    expect(decodeCaptionEntities("&lt;tag&gt;")).toBe("<tag>");
+    expect(decodeCaptionEntities("&quot;hi&quot;")).toBe('"hi"');
+    expect(decodeCaptionEntities("don&apos;t")).toBe("don't");
+  });
+
+  it("decodes the apostrophe variants the library covers and the ones it doesn't", () => {
+    expect(decodeCaptionEntities("I&#39;m here")).toBe("I'm here");
+    // The library's named-decode regex skips hex (&#x27;) — covered here.
+    expect(decodeCaptionEntities("can&#x27;t")).toBe("can't");
+    // Generic decimal numeric entities (e.g. em-dash &#8212;) — also not
+    // in the library's list.
+    expect(decodeCaptionEntities("hi &#8212; there")).toBe("hi — there");
+  });
+
+  it("unwraps double-encoded entities (the bug the user reported)", () => {
+    // YouTube sometimes emits `&amp;#39;`. After the library's single
+    // decode pass, `&amp;` -> `&`, leaving `&#39;`. The second pass here
+    // takes that to `'`. Without it, `I&#39;m` reaches the UI verbatim
+    // and React renders it as literal "I&#39;m".
+    expect(decodeCaptionEntities("I&amp;#39;m here")).toBe("I'm here");
+    expect(decodeCaptionEntities("&amp;amp;")).toBe("&");
+  });
+
+  it("is a no-op for plain text and Unicode that contains an ampersand", () => {
+    expect(decodeCaptionEntities("plain text")).toBe("plain text");
+    // Bare ampersand without entity shape stays intact (e.g. brand names
+    // like "AT&T" mid-transcript).
+    expect(decodeCaptionEntities("AT&T")).toBe("AT&T");
+    // Non-ASCII passes through.
+    expect(decodeCaptionEntities("café — naïve")).toBe("café — naïve");
   });
 });
 

--- a/src/lib/captions.ts
+++ b/src/lib/captions.ts
@@ -42,6 +42,45 @@ export interface CaptionResult {
   readonly channelName: string | null;
 }
 
+// `youtube-transcript-plus` already decodes the named XML entities
+// (`&amp; &lt; &gt; &quot; &apos; &#39;`) once, but YouTube sometimes
+// emits them double-encoded (`&amp;#39;` survives the first pass as
+// `&#39;`) and the library doesn't cover hex-numeric (`&#x27;`) or
+// arbitrary `&#NNN;` decimal entities at all. Run an iterative pass
+// here so the segment text we hand callers is a clean Unicode string —
+// otherwise React renders the literal `&` and users see "I&#39;m"
+// where they should see "I'm".
+//
+// Bounded to two passes total: enough to unwrap `&amp;<entity>;`
+// without risk of an infinite loop on adversarial input that happens
+// to keep producing entity-shaped substrings. Whisper output is plain
+// text so this only matters on the captions path.
+const NAMED_XML_ENTITIES: Readonly<Record<string, string>> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&apos;": "'",
+  "&nbsp;": " ",
+};
+
+function decodeEntitiesOnce(text: string): string {
+  return text
+    .replace(/&(amp|lt|gt|quot|apos|nbsp);/g, (m) => NAMED_XML_ENTITIES[m] ?? m)
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
+      String.fromCodePoint(parseInt(hex, 16))
+    )
+    .replace(/&#(\d+);/g, (_, dec) =>
+      String.fromCodePoint(parseInt(dec, 10))
+    );
+}
+
+export function decodeCaptionEntities(text: string): string {
+  const once = decodeEntitiesOnce(text);
+  if (once === text) return once;
+  return decodeEntitiesOnce(once);
+}
+
 // 11-char YouTube video IDs. Covers watch, youtu.be shortlink, Shorts,
 // and embed forms. Hostless so m.youtube.com / music.youtube.com flow
 // through the same patterns.
@@ -156,7 +195,7 @@ export async function fetchCaptions(
   const segments: TranscriptSegment[] = ytSegments
     .filter((s) => s.text.trim().length > 0)
     .map((s) => ({
-      text: s.text,
+      text: decodeCaptionEntities(s.text),
       start: s.offset,
       duration: s.duration,
     }));

--- a/src/lib/captions.ts
+++ b/src/lib/captions.ts
@@ -64,14 +64,31 @@ const NAMED_XML_ENTITIES: Readonly<Record<string, string>> = {
   "&nbsp;": " ",
 };
 
+// `String.fromCodePoint` throws RangeError for values > 0x10FFFF (e.g.
+// adversarial `&#999999999999;`). A defensive decoder must never throw —
+// a single malformed entity would otherwise crash the whole captions
+// fetch. Return the original match unchanged when the codepoint is out
+// of range so downstream sees the raw entity instead of a 500.
+const MAX_UNICODE_CODEPOINT = 0x10ffff;
+function safeFromCodePoint(cp: number, originalMatch: string): string {
+  if (!Number.isFinite(cp) || cp < 0 || cp > MAX_UNICODE_CODEPOINT) {
+    return originalMatch;
+  }
+  try {
+    return String.fromCodePoint(cp);
+  } catch {
+    return originalMatch;
+  }
+}
+
 function decodeEntitiesOnce(text: string): string {
   return text
     .replace(/&(amp|lt|gt|quot|apos|nbsp);/g, (m) => NAMED_XML_ENTITIES[m] ?? m)
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
-      String.fromCodePoint(parseInt(hex, 16))
+    .replace(/&#x([0-9a-fA-F]+);/g, (m, hex) =>
+      safeFromCodePoint(parseInt(hex, 16), m)
     )
-    .replace(/&#(\d+);/g, (_, dec) =>
-      String.fromCodePoint(parseInt(dec, 10))
+    .replace(/&#(\d+);/g, (m, dec) =>
+      safeFromCodePoint(parseInt(dec, 10), m)
     );
 }
 


### PR DESCRIPTION
## Summary
- Add `decodeCaptionEntities` to `src/lib/captions.ts` with bounded two-pass decoding for the named XML entities, hex/decimal numeric entities, and double-encoded forms.
- Apply it in `fetchCaptions` so segment text is clean before it leaves the service.

## Why
User reported transcripts rendering \`I&#39;m\` literally on the production page. Root cause:
- \`youtube-transcript-plus\` decodes named XML entities (\`&amp; &lt; &gt; &quot; &apos; &#39;\`) **once**.
- YouTube sometimes emits them double-encoded (\`&amp;#39;\` survives the first pass as \`&#39;\`).
- The library also doesn't cover hex (\`&#x27;\`) or arbitrary decimal (\`&#8212;\`) numerics.
- The undecoded text flows through to React, which escapes the leading \`&\` and renders the entity verbatim.

Bounded to two passes total — enough to unwrap \`&amp;<entity>;\` without looping forever on adversarial input.

## Scope
This fixes the canonical write path. Existing rows in \`video_transcripts.segments\` keep their encoded text until re-fetched; a companion frontend-side fix lands separately so those display clean without forcing re-transcription.

## Test plan
- [x] \`npm test\` — 182/182 pass; new \`decodeCaptionEntities\` block covers named, hex, decimal, double-encoded, plain text, bare \`&\`, non-ASCII
- [ ] Post-deploy: verify the user's video re-transcribes (or any new video) renders apostrophes clean in the transcript view