### PR TITLE
feat(metadata): expose video duration so frontend can fail fast on too-long videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Lightweight transcription microservice. Part of the YouTube AI Chat stack.
 
 ## Endpoints
 
-- `POST /metadata` — Extract video metadata (title, description, detected language, available caption track codes) via `yt-dlp --dump-json`. Call this first so the orchestrator can pin caption + whisper language and avoid the default "pick tracks[0]" bug that produced wrong-language transcripts.
+- `POST /metadata` — Extract video metadata (title, description, detected language, duration in seconds or `null`, available caption track codes) via `yt-dlp --dump-json`. Call this first so the orchestrator can pin caption + whisper language and avoid the default "pick tracks[0]" bug that produced wrong-language transcripts. `duration` lets callers fail fast on videos too long for the no-captions Whisper fallback to finish inside `VPS_TIMEOUT_MS`.
 - `POST /captions` — Fetch YouTube auto-captions for a video. Accepts an optional `lang` (ISO 639-1 or BCP-47) that forwards to `youtube-transcript-plus` so a specific caption track is selected. Returns 200 with `{ transcript, source, language, title, channelName }` or 404 `{ error: "no_captions" }` if the track isn't available. Much cheaper than transcription — call this before `/transcribe`.
 - `POST /transcribe` — Download audio via yt-dlp and transcribe with whisper-ctranslate2. Accepts an optional `lang` that forwards to whisper as `--language <code>` to bypass auto-detect. Fallback when captions aren't available.
 - `GET /health` — Health check (unauthenticated).

--- a/src/lib/__tests__/language-detect.test.ts
+++ b/src/lib/__tests__/language-detect.test.ts
@@ -10,6 +10,7 @@ const base: YtdlpMetadata = {
   title: "",
   description: "",
   language: null,
+  duration: null,
   subtitles: {},
   automatic_captions: {},
 };

--- a/src/lib/__tests__/ytdlp-metadata.test.ts
+++ b/src/lib/__tests__/ytdlp-metadata.test.ts
@@ -84,6 +84,7 @@ describe("fetchYtdlpMetadata", () => {
         title: "Test Video",
         description: "A test video",
         language: "fr",
+        duration: 213,
         subtitles: { fr: [{ url: "x", ext: "vtt" }] },
         automatic_captions: { en: [{ url: "y", ext: "vtt" }] },
       })
@@ -92,6 +93,7 @@ describe("fetchYtdlpMetadata", () => {
     expect(result.title).toBe("Test Video");
     expect(result.description).toBe("A test video");
     expect(result.language).toBe("fr");
+    expect(result.duration).toBe(213);
     expect(result.subtitles).toEqual({ fr: [{ url: "x", ext: "vtt" }] });
     expect(result.automatic_captions).toEqual({
       en: [{ url: "y", ext: "vtt" }],
@@ -108,8 +110,39 @@ describe("fetchYtdlpMetadata", () => {
     expect(result.title).toBe("Only Title");
     expect(result.description).toBe("");
     expect(result.language).toBeNull();
+    expect(result.duration).toBeNull();
     expect(result.subtitles).toEqual({});
     expect(result.automatic_captions).toEqual({});
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined (omitted)", undefined],
+    ["string", "10:30"],
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+    ["-Infinity", -Infinity],
+    ["negative", -5],
+  ])(
+    "collapses non-finite / non-numeric / negative duration (%s) to null",
+    async (_label, value) => {
+      // yt-dlp returns `null` on live streams and may emit non-numeric
+      // sentinels on schema regressions. Treating any of these as 0
+      // would silently pass any "video too long?" gate downstream and
+      // reintroduce the silent-hang bug — null forces the caller into
+      // "unknown, fall through" branch.
+      const payload: Record<string, unknown> = { id: "abc" };
+      if (value !== undefined) payload.duration = value;
+      mockExecSuccess(JSON.stringify(payload));
+      const result = await fetchYtdlpMetadata("https://youtu.be/abc");
+      expect(result.duration).toBeNull();
+    }
+  );
+
+  it("preserves duration=0 (a valid edge — zero-second clips exist)", async () => {
+    mockExecSuccess(JSON.stringify({ id: "abc", duration: 0 }));
+    const result = await fetchYtdlpMetadata("https://youtu.be/abc");
+    expect(result.duration).toBe(0);
   });
 
   it("throws when yt-dlp exits non-zero", async () => {

--- a/src/lib/__tests__/ytdlp-metadata.test.ts
+++ b/src/lib/__tests__/ytdlp-metadata.test.ts
@@ -118,7 +118,19 @@ describe("fetchYtdlpMetadata", () => {
   it.each([
     ["null", null],
     ["undefined (omitted)", undefined],
-    ["string", "10:30"],
+    // Numeric string is the realistic regression vector — a future
+    // maintainer adding `Number(obj.duration)` "to be helpful" would
+    // accept "213" as 213, silently passing the too-long gate when a
+    // yt-dlp version drift starts emitting strings.
+    ["numeric string", "213"],
+    ["non-numeric string", "10:30"],
+    // Booleans and objects are the well-meaning-coercion footguns —
+    // `Number(true)` is 1, `Number({})` is NaN. The strict typeof
+    // check rejects both before any arithmetic touches them.
+    ["boolean true", true],
+    ["boolean false", false],
+    ["object", { seconds: 213 }],
+    ["array", [213]],
     ["NaN", NaN],
     ["Infinity", Infinity],
     ["-Infinity", -Infinity],

--- a/src/lib/language-detect.ts
+++ b/src/lib/language-detect.ts
@@ -51,10 +51,12 @@ export interface YtdlpMetadata {
   readonly title: string;
   readonly description: string;
   readonly language: string | null;
-  // Length in seconds. `null` for live streams and the rare yt-dlp
-  // payload that omits the field — callers that gate behavior on
-  // duration must treat null as "unknown" and fall through, never as
-  // zero (which would unconditionally pass any "too long?" check).
+  // Length in seconds (non-negative finite, may be fractional).
+  // `null` for live streams, omitted payloads, and any non-finite or
+  // negative value rejected by the normalizer — callers that gate
+  // behavior on duration must treat null as "unknown" and fall
+  // through, never as zero (which would unconditionally pass any
+  // "too long?" check).
   readonly duration: number | null;
   readonly subtitles: Readonly<Record<string, readonly YtdlpCaptionTrack[]>>;
   readonly automatic_captions: Readonly<

--- a/src/lib/language-detect.ts
+++ b/src/lib/language-detect.ts
@@ -51,6 +51,11 @@ export interface YtdlpMetadata {
   readonly title: string;
   readonly description: string;
   readonly language: string | null;
+  // Length in seconds. `null` for live streams and the rare yt-dlp
+  // payload that omits the field — callers that gate behavior on
+  // duration must treat null as "unknown" and fall through, never as
+  // zero (which would unconditionally pass any "too long?" check).
+  readonly duration: number | null;
   readonly subtitles: Readonly<Record<string, readonly YtdlpCaptionTrack[]>>;
   readonly automatic_captions: Readonly<
     Record<string, readonly YtdlpCaptionTrack[]>

--- a/src/lib/ytdlp-metadata.ts
+++ b/src/lib/ytdlp-metadata.ts
@@ -99,9 +99,12 @@ function normalizeYtdlpJson(raw: unknown): YtdlpMetadata {
       ? obj.language
       : null;
   // yt-dlp emits `duration` as a number of seconds for VOD entries and
-  // omits it (or sets it to null) on live streams. Reject negative,
-  // NaN, and Infinity so a yt-dlp regression that fills the field with
-  // a sentinel can't flow through and bias downstream length checks.
+  // omits it (or sets it to null) on live streams. Anything that isn't
+  // a finite non-negative number — string, boolean, NaN, Infinity,
+  // negative, missing — collapses to `null` so a yt-dlp regression
+  // that fills the field with a sentinel can't flow through and bias
+  // downstream length checks. Zero is preserved (zero-second clips
+  // exist and are a legitimate VOD case).
   const duration =
     typeof obj.duration === "number" &&
     Number.isFinite(obj.duration) &&

--- a/src/lib/ytdlp-metadata.ts
+++ b/src/lib/ytdlp-metadata.ts
@@ -98,11 +98,22 @@ function normalizeYtdlpJson(raw: unknown): YtdlpMetadata {
     typeof obj.language === "string" && obj.language.length > 0
       ? obj.language
       : null;
+  // yt-dlp emits `duration` as a number of seconds for VOD entries and
+  // omits it (or sets it to null) on live streams. Reject negative,
+  // NaN, and Infinity so a yt-dlp regression that fills the field with
+  // a sentinel can't flow through and bias downstream length checks.
+  const duration =
+    typeof obj.duration === "number" &&
+    Number.isFinite(obj.duration) &&
+    obj.duration >= 0
+      ? obj.duration
+      : null;
 
   return {
     title,
     description,
     language,
+    duration,
     subtitles: normalizeCaptionDict(obj.subtitles),
     automatic_captions: normalizeCaptionDict(obj.automatic_captions),
   };

--- a/src/routes/__tests__/metadata.test.ts
+++ b/src/routes/__tests__/metadata.test.ts
@@ -43,11 +43,12 @@ describe("POST /metadata", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 200 with language, title, description, availableCaptions on happy path", async () => {
+  it("returns 200 with language, title, description, duration, availableCaptions on happy path", async () => {
     vi.spyOn(ytdlpMetadataLib, "fetchYtdlpMetadata").mockResolvedValue({
       title: "Comment apprendre",
       description: "Une vidéo en français",
       language: "fr",
+      duration: 893,
       subtitles: {},
       automatic_captions: { fr: [{ url: "x", ext: "vtt" }], en: [{ url: "x", ext: "vtt" }] },
     });
@@ -59,7 +60,28 @@ describe("POST /metadata", () => {
     expect(body.language).toBe("fr");
     expect(body.title).toBe("Comment apprendre");
     expect(body.description).toBe("Une vidéo en français");
+    expect(body.duration).toBe(893);
     expect(body.availableCaptions).toEqual(expect.arrayContaining(["fr", "en"]));
+  });
+
+  it("forwards duration=null (live streams) without coercing to 0", async () => {
+    // The frontend treats null as "duration unknown, fall through" — coercing
+    // to 0 here would silently pass any "video too long?" gate downstream
+    // and reintroduce the silent-hang bug for live streams.
+    vi.spyOn(ytdlpMetadataLib, "fetchYtdlpMetadata").mockResolvedValue({
+      title: "Live",
+      description: "",
+      language: "en",
+      duration: null,
+      subtitles: {},
+      automatic_captions: {},
+    });
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.duration).toBeNull();
   });
 
   it("returns 500 with a generic message when yt-dlp throws", async () => {

--- a/src/routes/__tests__/metadata.test.ts
+++ b/src/routes/__tests__/metadata.test.ts
@@ -1,6 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mocked at module scope so the end-to-end test below exercises the
+// real `fetchYtdlpMetadata` → `normalizeYtdlpJson` path. A vi.spyOn on
+// the imported namespace would bypass the normalizer and let the route
+// emit whatever the mock returns — defeating the regression-detection
+// purpose of the e2e check.
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from "child_process";
 import { metadata } from "../metadata.js";
 import * as ytdlpMetadataLib from "../../lib/ytdlp-metadata.js";
+
+const mockedExecFile = vi.mocked(execFile);
+const mockExecStdout = (stdout: string) => {
+  mockedExecFile.mockImplementation(
+    // @ts-expect-error execFile overloads don't narrow cleanly in mock
+    (_cmd, _args, _opts, cb) => {
+      cb?.(null, stdout, "");
+    }
+  );
+};
 
 const VALID_KEY = "test-key";
 
@@ -65,9 +86,9 @@ describe("POST /metadata", () => {
   });
 
   it("forwards duration=null (live streams) without coercing to 0", async () => {
-    // The frontend treats null as "duration unknown, fall through" — coercing
-    // to 0 here would silently pass any "video too long?" gate downstream
-    // and reintroduce the silent-hang bug for live streams.
+    // `null` must be forwarded verbatim — coercing to 0 here would break
+    // any "video too long?" gate by silently passing it. Live streams
+    // emit duration=null; same shape applies to schema gaps.
     vi.spyOn(ytdlpMetadataLib, "fetchYtdlpMetadata").mockResolvedValue({
       title: "Live",
       description: "",
@@ -98,6 +119,62 @@ describe("POST /metadata", () => {
     const body = await res.json();
     expect(body).toEqual({ error: "Metadata fetch failed" });
     expect(JSON.stringify(body)).not.toContain("/opt/tmp");
+  });
+});
+
+describe("POST /metadata — normalizer is on the route's code path", () => {
+  // These tests deliberately do NOT spy on `fetchYtdlpMetadata` — they
+  // mock the underlying `execFile` so a refactor that bypasses the
+  // normalizer (e.g. the route adds its own `Number(obj.duration)`
+  // parsing) breaks here. Without this, the unit-level normalizer
+  // tests and the route-level happy-path tests pass independently
+  // even when nothing connects them.
+  beforeEach(() => {
+    // restoreAllMocks (not just clearAllMocks) — the previous describe
+    // block leaves a `vi.spyOn(ytdlpMetadataLib, "fetchYtdlpMetadata")`
+    // in place that would shadow the real call path these tests are
+    // designed to exercise.
+    vi.restoreAllMocks();
+    process.env.VPS_API_KEY = VALID_KEY;
+  });
+
+  it("collapses negative duration to null on the wire", async () => {
+    mockExecStdout(
+      JSON.stringify({ id: "abc", title: "t", duration: -1 })
+    );
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.duration).toBeNull();
+  });
+
+  it("collapses string duration to null on the wire", async () => {
+    // Defends specifically against future `Number(obj.duration)` creep —
+    // a numeric string from a yt-dlp schema regression must not be
+    // accepted as a length signal.
+    mockExecStdout(
+      JSON.stringify({ id: "abc", title: "t", duration: "213" })
+    );
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.duration).toBeNull();
+  });
+
+  it("forwards a valid finite non-negative duration unchanged", async () => {
+    mockExecStdout(
+      JSON.stringify({ id: "abc", title: "t", duration: 213 })
+    );
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.duration).toBe(213);
   });
 });
 

--- a/src/routes/metadata.ts
+++ b/src/routes/metadata.ts
@@ -50,13 +50,15 @@ metadata.post("/", async (c) => {
       language,
       title: ytdlpMeta.title,
       description: ytdlpMeta.description,
-      // Surface duration so the frontend can fail fast on videos too
-      // long for the no-captions Whisper fallback to finish inside
-      // VPS_TIMEOUT_MS — without this signal the route silently hangs
-      // for the full timeout before returning a generic error.
-      // `null` when yt-dlp didn't supply a usable value (live streams
-      // and rare schema gaps); the frontend treats null as "unknown"
-      // and falls through to the legacy attempt.
+      // Surface duration so callers can fail fast on videos too long
+      // for the no-captions Whisper fallback to finish inside their
+      // /transcribe budget — without this signal a caller has no
+      // pre-flight evidence and learns the video was too long only
+      // after the full timeout. `null` means yt-dlp gave us no usable
+      // value (live streams, schema gaps, or any non-finite/negative
+      // sentinel rejected by the normalizer); the contract is "treat
+      // null as unknown, never as 0" — coercing would silently pass
+      // any too-long gate.
       duration: ytdlpMeta.duration,
       availableCaptions,
     });

--- a/src/routes/metadata.ts
+++ b/src/routes/metadata.ts
@@ -50,6 +50,14 @@ metadata.post("/", async (c) => {
       language,
       title: ytdlpMeta.title,
       description: ytdlpMeta.description,
+      // Surface duration so the frontend can fail fast on videos too
+      // long for the no-captions Whisper fallback to finish inside
+      // VPS_TIMEOUT_MS — without this signal the route silently hangs
+      // for the full timeout before returning a generic error.
+      // `null` when yt-dlp didn't supply a usable value (live streams
+      // and rare schema gaps); the frontend treats null as "unknown"
+      // and falls through to the legacy attempt.
+      duration: ytdlpMeta.duration,
       availableCaptions,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Add `duration` (seconds, or `null`) to `/metadata` response, sourced from yt-dlp's existing JSON
- Update `YtdlpMetadata` interface, `normalizeYtdlpJson` extractor, route response, and tests

## Why
The frontend's `/api/summarize/stream` calls `/transcribe` (yt-dlp + whisper-tiny CPU) when no captions are available. For multi-minute videos this can't finish inside the frontend's `VPS_TIMEOUT_MS` (240s, capped by Vercel's 300s `maxDuration`). The user sees "Transcribing 30%" for 4 minutes, then a generic error.

Reproduced live with `https://www.youtube.com/watch?v=D-dRD6zCpbY` (14-min Chinese video, no captions): SSE stream emits `metadata` + `Extracting captions...` (t≈1s) → `No captions found. Transcribing audio...` (t≈18s) → `error: Couldn't process this video` at exactly t≈258s = 17s captions + 240s VPS timeout.

Duration is the cheapest pre-check: yt-dlp already extracts it on the metadata-only call this route exists to make. Exposing it lets the frontend gate the Whisper fallback on length and produce an immediate, actionable error instead.

`null` is preserved for live streams and rare schema gaps; the frontend will treat null as "unknown" and fall through to the legacy attempt rather than coercing to 0.

This PR is purely additive (extra JSON field) — safe to deploy ahead of the matching frontend PR. Frontend's existing zod schema passes through unknown fields, so old frontend deployments remain unaffected.

## Test plan
- [x] `npm test` — 195/195 passing
- [x] `npx tsc --noEmit` — clean
- [x] Unit coverage for the new field: parsed numeric, null/undefined/NaN/Infinity/negative/string all collapse to `null`, `0` preserved (zero-second clips exist)
- [x] Route test asserts `duration` flows through and that `null` is preserved (not coerced)
- [ ] After merge + auto-deploy, frontend PR consumes the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)