### PR TITLE
fix(groq): compress audio before upload to fit 25MB limit

### DIFF
--- a/src/lib/__tests__/audio-compress.test.ts
+++ b/src/lib/__tests__/audio-compress.test.ts
@@ -1,13 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as childProcess from "child_process";
+import * as fsPromises from "fs/promises";
+import * as os from "os";
 import {
   compressForGroq,
+  cleanupCompressed,
   AudioCompressError,
 } from "../audio-compress.js";
 
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
 }));
+
+vi.mock("fs/promises", async () => {
+  const actual =
+    await vi.importActual<typeof import("fs/promises")>("fs/promises");
+  return { ...actual, unlink: vi.fn() };
+});
 
 // Cast through unknown — node's execFile overloads make the precise
 // callback type intractable to mock-impl directly, but the runtime
@@ -17,13 +26,22 @@ const mockedExecFile = childProcess.execFile as unknown as {
     fn: (
       file: string,
       args: readonly string[] | null | undefined,
-      opts: object | null | undefined,
-      cb: (err: Error | null, stdout: string, stderr: string) => void
+      opts: { timeout?: number } | null | undefined,
+      cb: (
+        err:
+          | (Error & { code?: string; killed?: boolean; signal?: string })
+          | null,
+        stdout: string,
+        stderr: string
+      ) => void
     ) => unknown
   ) => void;
   mockReset: () => void;
   mock: { calls: unknown[][] };
 };
+
+const mockedUnlink = vi.mocked(fsPromises.unlink);
+let warnSpy: ReturnType<typeof vi.spyOn>;
 
 function mockExecFileOk(): void {
   mockedExecFile.mockImplementation((_file, _args, _opts, cb) => {
@@ -32,10 +50,21 @@ function mockExecFileOk(): void {
   });
 }
 
-function mockExecFileFail(stderr: string): void {
+function mockExecFileFail(stderr: string, code?: string): void {
   mockedExecFile.mockImplementation((_file, _args, _opts, cb) => {
-    const err = new Error("ffmpeg exit 1");
+    const err = Object.assign(new Error("ffmpeg exit 1"), code ? { code } : {});
     cb(err, "", stderr);
+    return {};
+  });
+}
+
+function mockExecFileTimeoutKill(): void {
+  mockedExecFile.mockImplementation((_file, _args, _opts, cb) => {
+    const err = Object.assign(new Error("Command failed"), {
+      killed: true,
+      signal: "SIGTERM",
+    });
+    cb(err, "", "size=  500kB time=00:00:30");
     return {};
   });
 }
@@ -43,26 +72,35 @@ function mockExecFileFail(stderr: string): void {
 describe("compressForGroq", () => {
   beforeEach(() => {
     mockedExecFile.mockReset();
+    mockedUnlink.mockReset();
+    mockedUnlink.mockResolvedValue(undefined);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("invokes ffmpeg with 16kHz mono 32kbps mp3 args and returns the output path", async () => {
+  it("invokes ffmpeg with -loglevel error, 16kHz mono 32kbps mp3 args + 120s timeout, and returns the output path under tmpdir", async () => {
     mockExecFileOk();
 
     const out = await compressForGroq("/tmp/src.mp3");
 
     expect(out).toMatch(/^.+\/groq-[0-9a-f-]+\.mp3$/);
+    expect(out.startsWith(os.tmpdir())).toBe(true);
     expect(mockedExecFile.mock.calls).toHaveLength(1);
-    const [cmd, args] = mockedExecFile.mock.calls[0] as unknown as [
+    const [cmd, args, opts] = mockedExecFile.mock.calls[0] as unknown as [
       string,
       string[],
+      { timeout?: number },
     ];
     expect(cmd).toBe("ffmpeg");
+    // Encoder flags asserted positionally because ffmpeg parses ordered
+    // pairs; the test will surface a real arg-order regression.
     expect(args).toEqual([
       "-y",
+      "-loglevel",
+      "error",
       "-i",
       "/tmp/src.mp3",
       "-ar",
@@ -75,28 +113,117 @@ describe("compressForGroq", () => {
       "mp3",
       out,
     ]);
+    expect(opts.timeout).toBe(120_000);
   });
 
-  it("throws AudioCompressError carrying the ffmpeg stderr when re-encode fails", async () => {
+  it("classifies execFile timeout-kill as kind='timeout' regardless of stderr content", async () => {
+    mockExecFileTimeoutKill();
+
+    const err = await compressForGroq("/tmp/src.mp3").catch((e) => e);
+
+    expect(err).toBeInstanceOf(AudioCompressError);
+    expect(err.kind).toBe("timeout");
+    // Detail mentions the timeout budget so an operator reading logs
+    // can correlate against runtime configuration.
+    expect(err.detail).toMatch(/120000ms/);
+    // Original Error preserved for stack-chain debugging.
+    expect(err.cause).toBeDefined();
+  });
+
+  it("classifies missing ffmpeg binary (ENOENT) as kind='missing-binary'", async () => {
+    mockExecFileFail("", "ENOENT");
+
+    const err = await compressForGroq("/tmp/src.mp3").catch((e) => e);
+
+    expect(err).toBeInstanceOf(AudioCompressError);
+    expect(err.kind).toBe("missing-binary");
+    expect(err.cause).toMatchObject({ code: "ENOENT" });
+  });
+
+  it("classifies generic ffmpeg failure as kind='ffmpeg-failed' carrying stderr", async () => {
     mockExecFileFail("Invalid data found when processing input");
 
-    await expect(compressForGroq("/tmp/src.mp3")).rejects.toBeInstanceOf(
-      AudioCompressError
-    );
-    await expect(compressForGroq("/tmp/src.mp3")).rejects.toMatchObject({
-      stderr: expect.stringContaining("Invalid data"),
-    });
+    const err = await compressForGroq("/tmp/src.mp3").catch((e) => e);
+
+    expect(err).toBeInstanceOf(AudioCompressError);
+    expect(err.kind).toBe("ffmpeg-failed");
+    expect(err.detail).toContain("Invalid data");
   });
 
-  it("falls back to error.message when ffmpeg's stderr is empty", async () => {
+  it("falls back to error.message when ffmpeg's stderr is empty (kind='ffmpeg-failed')", async () => {
     mockedExecFile.mockImplementation((_file, _args, _opts, cb) => {
-      const err = new Error("ENOENT: ffmpeg not found");
-      cb(err, "", "");
+      cb(new Error("EPIPE"), "", "");
       return {};
     });
 
-    await expect(compressForGroq("/tmp/src.mp3")).rejects.toMatchObject({
-      stderr: expect.stringContaining("ENOENT"),
-    });
+    const err = await compressForGroq("/tmp/src.mp3").catch((e) => e);
+
+    expect(err.kind).toBe("ffmpeg-failed");
+    expect(err.detail).toContain("EPIPE");
+  });
+
+  it("unlinks the partial dst file when ffmpeg fails (so a SIGTERM-killed mp3 doesn't leak to /tmp)", async () => {
+    mockExecFileTimeoutKill();
+
+    await compressForGroq("/tmp/src.mp3").catch(() => undefined);
+
+    expect(mockedUnlink).toHaveBeenCalledTimes(1);
+    expect(mockedUnlink.mock.calls[0]?.[0]).toMatch(
+      /^.+\/groq-[0-9a-f-]+\.mp3$/
+    );
+  });
+
+  it("survives unlink-of-partial-file failure on the failure path (still rejects with AudioCompressError)", async () => {
+    mockExecFileTimeoutKill();
+    // ENOENT here means ffmpeg never wrote anything — fine, swallow.
+    mockedUnlink.mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    );
+
+    const err = await compressForGroq("/tmp/src.mp3").catch((e) => e);
+
+    expect(err).toBeInstanceOf(AudioCompressError);
+    expect(err.kind).toBe("timeout");
+  });
+});
+
+describe("cleanupCompressed", () => {
+  beforeEach(() => {
+    mockedUnlink.mockReset();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("succeeds silently when unlink succeeds", async () => {
+    mockedUnlink.mockResolvedValue(undefined);
+
+    await expect(cleanupCompressed("/tmp/groq-x.mp3")).resolves.toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats ENOENT as benign — no warn (caller may have cleaned up already)", async () => {
+    mockedUnlink.mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    );
+
+    await expect(cleanupCompressed("/tmp/groq-x.mp3")).resolves.toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns with CLEANUP_COMPRESSED_FAILED on non-ENOENT errors (leak/observability signal)", async () => {
+    mockedUnlink.mockRejectedValueOnce(
+      Object.assign(new Error("EACCES"), { code: "EACCES" })
+    );
+
+    await expect(cleanupCompressed("/tmp/groq-x.mp3")).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [msg, ctx] = warnSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(msg).toContain("CLEANUP_COMPRESSED_FAILED");
+    expect(ctx.errorId).toBe("CLEANUP_COMPRESSED_FAILED");
+    expect(ctx.path).toBe("/tmp/groq-x.mp3");
+    expect(ctx.error).toContain("EACCES");
   });
 });

--- a/src/lib/__tests__/audio-compress.test.ts
+++ b/src/lib/__tests__/audio-compress.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as childProcess from "child_process";
+import {
+  compressForGroq,
+  AudioCompressError,
+} from "../audio-compress.js";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+// Cast through unknown — node's execFile overloads make the precise
+// callback type intractable to mock-impl directly, but the runtime
+// shape (4 args, 4th is the callback) is what we need.
+const mockedExecFile = childProcess.execFile as unknown as {
+  mockImplementation: (
+    fn: (
+      file: string,
+      args: readonly string[] | null | undefined,
+      opts: object | null | undefined,
+      cb: (err: Error | null, stdout: string, stderr: string) => void
+    ) => unknown
+  ) => void;
+  mockReset: () => void;
+  mock: { calls: unknown[][] };
+};
+
+function mockExecFileOk(): void {
+  mockedExecFile.mockImplementation((_file, _args, _opts, cb) => {
+    cb(null, "", "");
+    return {};
+  });
+}
+
+function mockExecFileFail(stderr: string): void {
+  mockedExecFile.mockImplementation((_file, _args, _opts, cb) => {
+    const err = new Error("ffmpeg exit 1");
+    cb(err, "", stderr);
+    return {};
+  });
+}
+
+describe("compressForGroq", () => {
+  beforeEach(() => {
+    mockedExecFile.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("invokes ffmpeg with 16kHz mono 32kbps mp3 args and returns the output path", async () => {
+    mockExecFileOk();
+
+    const out = await compressForGroq("/tmp/src.mp3");
+
+    expect(out).toMatch(/^.+\/groq-[0-9a-f-]+\.mp3$/);
+    expect(mockedExecFile.mock.calls).toHaveLength(1);
+    const [cmd, args] = mockedExecFile.mock.calls[0] as unknown as [
+      string,
+      string[],
+    ];
+    expect(cmd).toBe("ffmpeg");
+    expect(args).toEqual([
+      "-y",
+      "-i",
+      "/tmp/src.mp3",
+      "-ar",
+      "16000",
+      "-ac",
+      "1",
+      "-b:a",
+      "32k",
+      "-f",
+      "mp3",
+      out,
+    ]);
+  });
+
+  it("throws AudioCompressError carrying the ffmpeg stderr when re-encode fails", async () => {
+    mockExecFileFail("Invalid data found when processing input");
+
+    await expect(compressForGroq("/tmp/src.mp3")).rejects.toBeInstanceOf(
+      AudioCompressError
+    );
+    await expect(compressForGroq("/tmp/src.mp3")).rejects.toMatchObject({
+      stderr: expect.stringContaining("Invalid data"),
+    });
+  });
+
+  it("falls back to error.message when ffmpeg's stderr is empty", async () => {
+    mockedExecFile.mockImplementation((_file, _args, _opts, cb) => {
+      const err = new Error("ENOENT: ffmpeg not found");
+      cb(err, "", "");
+      return {};
+    });
+
+    await expect(compressForGroq("/tmp/src.mp3")).rejects.toMatchObject({
+      stderr: expect.stringContaining("ENOENT"),
+    });
+  });
+});

--- a/src/lib/__tests__/groq-transcribe.test.ts
+++ b/src/lib/__tests__/groq-transcribe.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { readFile } from "fs/promises";
+import * as audioCompress from "../audio-compress.js";
 import {
   transcribeViaGroq,
   GroqTranscribeError,
@@ -10,7 +11,23 @@ vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
 }));
 
+// Mock audio-compress so tests don't shell out to ffmpeg; we just
+// verify Groq receives the path the compressor returned.
+vi.mock("../audio-compress.js", () => ({
+  AudioCompressError: class AudioCompressError extends Error {
+    constructor(public readonly stderr: string) {
+      super(`Audio compression failed: ${stderr.slice(0, 200)}`);
+      this.name = "AudioCompressError";
+    }
+  },
+  compressForGroq: vi.fn(),
+  cleanupCompressed: vi.fn(),
+}));
+
 const mockedReadFile = vi.mocked(readFile);
+const mockedCompress = vi.mocked(audioCompress.compressForGroq);
+const mockedCleanup = vi.mocked(audioCompress.cleanupCompressed);
+const COMPRESSED_PATH = "/tmp/groq-compressed.mp3";
 const validGroqBody = {
   language: "en",
   segments: [
@@ -30,12 +47,16 @@ describe("transcribeViaGroq", () => {
   beforeEach(() => {
     vi.stubEnv("GROQ_API_KEY", "test-key");
     mockedReadFile.mockResolvedValue(Buffer.from("fake-audio-bytes"));
+    mockedCompress.mockResolvedValue(COMPRESSED_PATH);
+    mockedCleanup.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
+    mockedCompress.mockReset();
+    mockedCleanup.mockReset();
   });
 
   it("posts the audio file and parses Groq's verbose_json into our segment shape", async () => {
@@ -192,6 +213,66 @@ describe("transcribeViaGroq", () => {
     const result = await transcribeViaGroq("/tmp/clip.mp3");
     expect(result.segments).toEqual([]);
     expect(result.language).toBe("en");
+  });
+
+  it("compresses audio before upload and sends the compressed file's bytes to Groq", async () => {
+    // The original yt-dlp output (~245kbps mp3) blows past Groq's 25MB
+    // free-tier limit at ~13 min of audio. We re-encode to 16kHz mono
+    // 32kbps mp3 first, then upload that smaller file.
+    mockedReadFile.mockReset();
+    mockedReadFile.mockImplementation(async (path: unknown) => {
+      if (path === COMPRESSED_PATH) return Buffer.from("compressed-bytes");
+      return Buffer.from("ORIGINAL-DO-NOT-UPLOAD");
+    });
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(validGroqBody));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await transcribeViaGroq("/tmp/clip-orig.mp3");
+
+    expect(mockedCompress).toHaveBeenCalledWith("/tmp/clip-orig.mp3");
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const formData = init.body as FormData;
+    const file = formData.get("file") as File;
+    const sentBytes = Buffer.from(await file.arrayBuffer());
+    expect(sentBytes.toString()).toBe("compressed-bytes");
+  });
+
+  it("cleans up the compressed temp file even when Groq returns 5xx", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("boom", { status: 500 }))
+    );
+
+    await expect(transcribeViaGroq("/tmp/clip.mp3")).rejects.toMatchObject({
+      status: 500,
+    });
+    expect(mockedCleanup).toHaveBeenCalledWith(COMPRESSED_PATH);
+  });
+
+  it("cleans up the compressed temp file on the happy path", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(okResponse(validGroqBody)));
+
+    await transcribeViaGroq("/tmp/clip.mp3");
+
+    expect(mockedCleanup).toHaveBeenCalledWith(COMPRESSED_PATH);
+  });
+
+  it("throws GroqTranscribeError(status='compress') when re-encode fails", async () => {
+    // ffmpeg failure is treated symmetrically with a Groq-side failure
+    // so the route's catch can apply the same fallback rules.
+    mockedCompress.mockRejectedValueOnce(
+      new audioCompress.AudioCompressError("Invalid data found in input")
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(transcribeViaGroq("/tmp/clip.mp3")).rejects.toMatchObject({
+      status: "compress",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    // No compressed file was produced, so cleanup must not be called
+    // with a stale value.
+    expect(mockedCleanup).not.toHaveBeenCalled();
   });
 
   it("coerces a segment whose start > end to duration=0 (defensive)", async () => {

--- a/src/lib/__tests__/groq-transcribe.test.ts
+++ b/src/lib/__tests__/groq-transcribe.test.ts
@@ -11,18 +11,20 @@ vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
 }));
 
-// Mock audio-compress so tests don't shell out to ffmpeg; we just
-// verify Groq receives the path the compressor returned.
-vi.mock("../audio-compress.js", () => ({
-  AudioCompressError: class AudioCompressError extends Error {
-    constructor(public readonly stderr: string) {
-      super(`Audio compression failed: ${stderr.slice(0, 200)}`);
-      this.name = "AudioCompressError";
-    }
-  },
-  compressForGroq: vi.fn(),
-  cleanupCompressed: vi.fn(),
-}));
+// Mock the I/O surfaces of audio-compress (compressForGroq, cleanupCompressed)
+// without redefining AudioCompressError — vi.importActual preserves the real
+// class so the prod `instanceof AudioCompressError` check at the call site
+// is exercised against the actual class identity, not a test-local shadow.
+vi.mock("../audio-compress.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../audio-compress.js")
+  >("../audio-compress.js");
+  return {
+    ...actual,
+    compressForGroq: vi.fn(),
+    cleanupCompressed: vi.fn(),
+  };
+});
 
 const mockedReadFile = vi.mocked(readFile);
 const mockedCompress = vi.mocked(audioCompress.compressForGroq);
@@ -55,8 +57,6 @@ describe("transcribeViaGroq", () => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
-    mockedCompress.mockReset();
-    mockedCleanup.mockReset();
   });
 
   it("posts the audio file and parses Groq's verbose_json into our segment shape", async () => {
@@ -215,10 +215,10 @@ describe("transcribeViaGroq", () => {
     expect(result.language).toBe("en");
   });
 
-  it("compresses audio before upload and sends the compressed file's bytes to Groq", async () => {
-    // The original yt-dlp output (~245kbps mp3) blows past Groq's 25MB
-    // free-tier limit at ~13 min of audio. We re-encode to 16kHz mono
-    // 32kbps mp3 first, then upload that smaller file.
+  it("compresses before upload, reads only the compressed path, and uploads with a .mp3 filename", async () => {
+    // Sanity-check that the compressed bytes (not the original) reach
+    // Groq, AND that the filename Groq uses for format detection ends
+    // in .mp3. See audio-compress.ts for the bitrate / 25 MB rationale.
     mockedReadFile.mockReset();
     mockedReadFile.mockImplementation(async (path: unknown) => {
       if (path === COMPRESSED_PATH) return Buffer.from("compressed-bytes");
@@ -230,11 +230,17 @@ describe("transcribeViaGroq", () => {
     await transcribeViaGroq("/tmp/clip-orig.mp3");
 
     expect(mockedCompress).toHaveBeenCalledWith("/tmp/clip-orig.mp3");
+    expect(mockedReadFile).toHaveBeenCalledWith(COMPRESSED_PATH);
+    expect(mockedReadFile).not.toHaveBeenCalledWith("/tmp/clip-orig.mp3");
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     const formData = init.body as FormData;
     const file = formData.get("file") as File;
     const sentBytes = Buffer.from(await file.arrayBuffer());
     expect(sentBytes.toString()).toBe("compressed-bytes");
+    // Groq trusts the multipart filename extension for format detection,
+    // so a regression that uploads compressed bytes under the original
+    // (non-mp3) filename would silently break Groq. Pin .mp3.
+    expect(file.name).toMatch(/\.mp3$/);
   });
 
   it("cleans up the compressed temp file even when Groq returns 5xx", async () => {
@@ -257,18 +263,24 @@ describe("transcribeViaGroq", () => {
     expect(mockedCleanup).toHaveBeenCalledWith(COMPRESSED_PATH);
   });
 
-  it("throws GroqTranscribeError(status='compress') when re-encode fails", async () => {
+  it("throws GroqTranscribeError(status='compress') when re-encode fails, carrying the kind in the body excerpt", async () => {
     // ffmpeg failure is treated symmetrically with a Groq-side failure
-    // so the route's catch can apply the same fallback rules.
+    // so the route's catch can apply the same fallback rules. The kind
+    // travels via bodyExcerpt so route logs distinguish missing-binary
+    // (deploy regression) from ffmpeg-failed (bad input) from timeout.
     mockedCompress.mockRejectedValueOnce(
-      new audioCompress.AudioCompressError("Invalid data found in input")
+      new audioCompress.AudioCompressError(
+        "ffmpeg-failed",
+        "Invalid data found in input"
+      )
     );
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(transcribeViaGroq("/tmp/clip.mp3")).rejects.toMatchObject({
-      status: "compress",
-    });
+    const err = await transcribeViaGroq("/tmp/clip.mp3").catch((e) => e);
+    expect(err.status).toBe("compress");
+    expect(err.bodyExcerpt).toContain("ffmpeg-failed");
+    expect(err.bodyExcerpt).toContain("Invalid data");
     expect(fetchMock).not.toHaveBeenCalled();
     // No compressed file was produced, so cleanup must not be called
     // with a stale value.

--- a/src/lib/audio-compress.ts
+++ b/src/lib/audio-compress.ts
@@ -1,0 +1,54 @@
+import { execFile } from "child_process";
+import { randomUUID } from "crypto";
+import { unlink } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+export class AudioCompressError extends Error {
+  constructor(public readonly stderr: string) {
+    super(`Audio compression failed: ${stderr.slice(0, 200)}`);
+    this.name = "AudioCompressError";
+  }
+}
+
+const FFMPEG_TIMEOUT_MS = 120_000;
+
+// 16 kHz mono 32 kbps mp3. Whisper's training corpus is 16 kHz mono so the
+// downsample is loss-free for transcription accuracy; 32 kbps mp3 is well
+// above the speech-intelligibility floor while comfortably fitting Groq's
+// 25 MB free-tier upload limit (≈ 6.7 MB / 28 min, ≈ 24 MB / 100 min).
+export async function compressForGroq(srcPath: string): Promise<string> {
+  const dstPath = join(tmpdir(), `groq-${randomUUID()}.mp3`);
+  await new Promise<void>((resolve, reject) => {
+    execFile(
+      "ffmpeg",
+      [
+        "-y",
+        "-i",
+        srcPath,
+        "-ar",
+        "16000",
+        "-ac",
+        "1",
+        "-b:a",
+        "32k",
+        "-f",
+        "mp3",
+        dstPath,
+      ],
+      { timeout: FFMPEG_TIMEOUT_MS },
+      (error, _stdout, stderr) => {
+        if (error) {
+          reject(new AudioCompressError(stderr || error.message));
+          return;
+        }
+        resolve();
+      }
+    );
+  });
+  return dstPath;
+}
+
+export async function cleanupCompressed(path: string): Promise<void> {
+  await unlink(path).catch(() => undefined);
+}

--- a/src/lib/audio-compress.ts
+++ b/src/lib/audio-compress.ts
@@ -4,9 +4,22 @@ import { unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 
+// Three-arm discriminator so callers (and prod logs) can tell apart
+// "ffmpeg isn't installed" from "ffmpeg ran but bailed on the input"
+// from "we killed ffmpeg at the timeout." Ops triage is materially
+// different for each.
+export type AudioCompressKind =
+  | "missing-binary"
+  | "timeout"
+  | "ffmpeg-failed";
+
 export class AudioCompressError extends Error {
-  constructor(public readonly stderr: string) {
-    super(`Audio compression failed: ${stderr.slice(0, 200)}`);
+  constructor(
+    public readonly kind: AudioCompressKind,
+    public readonly detail: string,
+    public readonly cause?: Error
+  ) {
+    super(`Audio compression failed (${kind}): ${detail.slice(0, 200)}`);
     this.name = "AudioCompressError";
   }
 }
@@ -14,41 +27,118 @@ export class AudioCompressError extends Error {
 const FFMPEG_TIMEOUT_MS = 120_000;
 
 // 16 kHz mono 32 kbps mp3. Whisper's training corpus is 16 kHz mono so the
-// downsample is loss-free for transcription accuracy; 32 kbps mp3 is well
-// above the speech-intelligibility floor while comfortably fitting Groq's
-// 25 MB free-tier upload limit (≈ 6.7 MB / 28 min, ≈ 24 MB / 100 min).
+// downsample is transcription-neutral — Whisper itself resamples back to
+// that same rate before inference. 32 kbps mp3 sits comfortably above the
+// speech-intelligibility floor while shrinking the upload roughly an order
+// of magnitude vs yt-dlp's `--audio-quality 0` output (~245 kbps VBR),
+// keeping the compressed file under Groq's 25 MB free-tier cap for the
+// vast majority of YouTube content (≈ 240 KB/min ⇒ ~100 min headroom).
 export async function compressForGroq(srcPath: string): Promise<string> {
   const dstPath = join(tmpdir(), `groq-${randomUUID()}.mp3`);
-  await new Promise<void>((resolve, reject) => {
-    execFile(
-      "ffmpeg",
-      [
-        "-y",
-        "-i",
-        srcPath,
-        "-ar",
-        "16000",
-        "-ac",
-        "1",
-        "-b:a",
-        "32k",
-        "-f",
-        "mp3",
-        dstPath,
-      ],
-      { timeout: FFMPEG_TIMEOUT_MS },
-      (error, _stdout, stderr) => {
-        if (error) {
-          reject(new AudioCompressError(stderr || error.message));
-          return;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      execFile(
+        "ffmpeg",
+        [
+          "-y",
+          // `-loglevel error`: drop ffmpeg's per-input banner and progress
+          // chatter so a 200-char detail excerpt actually contains the
+          // failure reason rather than copyright text.
+          "-loglevel",
+          "error",
+          "-i",
+          srcPath,
+          "-ar",
+          "16000",
+          "-ac",
+          "1",
+          "-b:a",
+          "32k",
+          "-f",
+          "mp3",
+          dstPath,
+        ],
+        { timeout: FFMPEG_TIMEOUT_MS },
+        (error, _stdout, stderr) => {
+          if (error) {
+            const stderrStr =
+              typeof stderr === "string" ? stderr : String(stderr);
+            const trimmedStderr = stderrStr.trim();
+            // node sets `killed: true` (and signal: SIGTERM) when the
+            // execFile timeout fires. stderr at the kill instant is
+            // typically truncated mid-line, so we synthesize a useful
+            // detail rather than leaking partial output.
+            if (
+              error.killed === true ||
+              error.signal === "SIGTERM"
+            ) {
+              reject(
+                new AudioCompressError(
+                  "timeout",
+                  `ffmpeg killed by ${FFMPEG_TIMEOUT_MS}ms timeout`,
+                  error
+                )
+              );
+              return;
+            }
+            // ENOENT from execFile means the `ffmpeg` binary itself isn't
+            // on PATH — that's a deploy/container regression, not bad
+            // input, and ops needs to see it as such.
+            if (error.code === "ENOENT") {
+              reject(
+                new AudioCompressError(
+                  "missing-binary",
+                  error.message,
+                  error
+                )
+              );
+              return;
+            }
+            reject(
+              new AudioCompressError(
+                "ffmpeg-failed",
+                trimmedStderr || error.message,
+                error
+              )
+            );
+            return;
+          }
+          resolve();
         }
-        resolve();
-      }
-    );
-  });
+      );
+    });
+  } catch (err) {
+    // ffmpeg may have written a partial mp3 (especially on timeout-kill
+    // mid-encode) — unlink before propagating so we don't leak a temp
+    // file the caller can't see.
+    await unlink(dstPath).catch(() => undefined);
+    throw err;
+  }
   return dstPath;
 }
 
+// Logs non-ENOENT failures explicitly. ENOENT here means "already gone"
+// which is fine on every cleanup path. Anything else (EACCES, EBUSY,
+// EROFS, EMFILE, ENOSPC) is a leak/observability signal — silent-swallow
+// would let `/tmp` fill up unnoticed, which is exactly what bit
+// `ytdlp.cleanupAudio` historically.
 export async function cleanupCompressed(path: string): Promise<void> {
-  await unlink(path).catch(() => undefined);
+  await unlink(path).catch((err: unknown) => {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as { code?: string }).code === "ENOENT"
+    ) {
+      return;
+    }
+    console.warn(
+      `[audio-compress] CLEANUP_COMPRESSED_FAILED for ${path}`,
+      {
+        errorId: "CLEANUP_COMPRESSED_FAILED",
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      }
+    );
+  });
 }

--- a/src/lib/groq-transcribe.ts
+++ b/src/lib/groq-transcribe.ts
@@ -74,20 +74,25 @@ export async function transcribeViaGroq(
       : DEFAULT_TIMEOUT_MS;
 
   // Re-encode to 16 kHz mono 32 kbps mp3 before upload. yt-dlp's
-  // `--audio-quality 0` mp3 averages ~245 kbps VBR, which exceeds Groq's
-  // 25 MB free-tier limit at ~13 minutes of audio. Compression is loss-
-  // free for transcription accuracy (Whisper trains at 16 kHz mono) and
-  // shrinks the upload by ~7×.
+  // `--audio-quality 0` mp3 produces ~245 kbps VBR, which blows past
+  // Groq's 25 MB free-tier upload cap once audio crosses ~14 min.
+  // Downsampling to Whisper's native 16 kHz mono is transcription-
+  // neutral (Whisper resamples to that rate before inference anyway).
   let uploadPath: string;
   try {
     uploadPath = await compressForGroq(audioPath);
   } catch (err) {
     if (err instanceof AudioCompressError) {
       // Surface as a Groq-side failure so the route's catch can apply
-      // the same fallback rules (eligible for local Whisper iff audio
-      // ≤ GROQ_LOCAL_FALLBACK_MAX_SECONDS, else 503). From the route's
-      // perspective the cloud path is unavailable for this request.
-      throw new GroqTranscribeError("compress", err.stderr);
+      // the same fallback rules — eligible for local Whisper iff the
+      // audio is short enough per the route's fallback cap, else 503.
+      // Detail string carries the AudioCompressError kind so the route
+      // log distinguishes "missing-binary" (deploy regression) from
+      // "ffmpeg-failed" (bad input) from "timeout" (host saturation).
+      throw new GroqTranscribeError(
+        "compress",
+        `${err.kind}: ${err.detail}`
+      );
     }
     throw err;
   }
@@ -181,6 +186,23 @@ export async function transcribeViaGroq(
     // "Transcription produced no content."
     return { segments, language: parsed.data.language ?? lang ?? "auto" };
   } finally {
-    await cleanupCompressed(uploadPath);
+    // Defensive: cleanupCompressed today swallows non-leak errors (logs
+    // them) so it should never throw, but a future cleanup-error policy
+    // change must NOT swallow the body's throw via finally semantics.
+    try {
+      await cleanupCompressed(uploadPath);
+    } catch (cleanupErr) {
+      console.warn(
+        `[groq-transcribe] CLEANUP_COMPRESSED_THREW for ${uploadPath}`,
+        {
+          errorId: "CLEANUP_COMPRESSED_THREW",
+          path: uploadPath,
+          error:
+            cleanupErr instanceof Error
+              ? cleanupErr.message
+              : String(cleanupErr),
+        }
+      );
+    }
   }
 }

--- a/src/lib/groq-transcribe.ts
+++ b/src/lib/groq-transcribe.ts
@@ -1,5 +1,10 @@
 import { readFile } from "fs/promises";
 import { z } from "zod";
+import {
+  AudioCompressError,
+  cleanupCompressed,
+  compressForGroq,
+} from "./audio-compress.js";
 import type { TranscriptSegment } from "./captions.js";
 
 // Subset of Groq's `verbose_json` response we consume. Groq's full shape
@@ -23,7 +28,12 @@ export const GroqResponseSchema = z.object({
 // errors (and the synthetic "schema" we raise on Zod parse failures).
 export class GroqTranscribeError extends Error {
   constructor(
-    public readonly status: number | "network" | "timeout" | "schema",
+    public readonly status:
+      | number
+      | "network"
+      | "timeout"
+      | "schema"
+      | "compress",
     public readonly bodyExcerpt?: string
   ) {
     super(
@@ -63,95 +73,114 @@ export async function transcribeViaGroq(
       ? rawTimeout
       : DEFAULT_TIMEOUT_MS;
 
-  const fileBytes = await readFile(audioPath);
-  const buildBody = () => {
-    const body = new FormData();
-    body.append(
-      "file",
-      // Groq's API ignores the multipart MIME and trusts the filename
-      // extension for format detection, so a single hardcoded MIME is
-      // safe across yt-dlp's output formats (mp3 / m4a / opus / webm).
-      new Blob([fileBytes], { type: "audio/mpeg" }),
-      // `||` (not `??`) so empty string + paths ending in `/` also fall
-      // through to the default filename. Defensive — yt-dlp produces
-      // real paths in practice.
-      audioPath.split("/").pop() || "audio.mp3"
-    );
-    body.append("model", model);
-    body.append("response_format", "verbose_json");
-    if (lang) body.append("language", lang);
-    return body;
-  };
-
-  const doFetch = () =>
-    fetch(GROQ_URL, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${apiKey}` },
-      body: buildBody(),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-
-  let resp: Response;
+  // Re-encode to 16 kHz mono 32 kbps mp3 before upload. yt-dlp's
+  // `--audio-quality 0` mp3 averages ~245 kbps VBR, which exceeds Groq's
+  // 25 MB free-tier limit at ~13 minutes of audio. Compression is loss-
+  // free for transcription accuracy (Whisper trains at 16 kHz mono) and
+  // shrinks the upload by ~7×.
+  let uploadPath: string;
   try {
-    resp = await doFetch();
-    // Single retry on 429. Free-tier rate limits are per-minute, so a
-    // brief backoff usually clears. We deliberately do NOT retry 5xx —
-    // Groq's incidents tend to last longer than 2s and we want to fail
-    // through to the local fallback quickly.
-    if (resp.status === 429) {
-      await new Promise((r) => setTimeout(r, RETRY_BACKOFF_MS));
+    uploadPath = await compressForGroq(audioPath);
+  } catch (err) {
+    if (err instanceof AudioCompressError) {
+      // Surface as a Groq-side failure so the route's catch can apply
+      // the same fallback rules (eligible for local Whisper iff audio
+      // ≤ GROQ_LOCAL_FALLBACK_MAX_SECONDS, else 503). From the route's
+      // perspective the cloud path is unavailable for this request.
+      throw new GroqTranscribeError("compress", err.stderr);
+    }
+    throw err;
+  }
+
+  try {
+    const fileBytes = await readFile(uploadPath);
+    const buildBody = () => {
+      const body = new FormData();
+      body.append(
+        "file",
+        new Blob([fileBytes], { type: "audio/mpeg" }),
+        // Compressed filename ends in .mp3 by construction; Groq trusts
+        // the extension for format detection.
+        uploadPath.split("/").pop() || "audio.mp3"
+      );
+      body.append("model", model);
+      body.append("response_format", "verbose_json");
+      if (lang) body.append("language", lang);
+      return body;
+    };
+
+    const doFetch = () =>
+      fetch(GROQ_URL, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${apiKey}` },
+        body: buildBody(),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+
+    let resp: Response;
+    try {
       resp = await doFetch();
+      // Single retry on 429. Free-tier rate limits are per-minute, so a
+      // brief backoff usually clears. We deliberately do NOT retry 5xx —
+      // Groq's incidents tend to last longer than 2s and we want to fail
+      // through to the local fallback quickly.
+      if (resp.status === 429) {
+        await new Promise((r) => setTimeout(r, RETRY_BACKOFF_MS));
+        resp = await doFetch();
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === "TimeoutError") {
+        throw new GroqTranscribeError("timeout");
+      }
+      throw new GroqTranscribeError(
+        "network",
+        err instanceof Error ? err.message : String(err)
+      );
     }
-  } catch (err) {
-    if (err instanceof Error && err.name === "TimeoutError") {
-      throw new GroqTranscribeError("timeout");
+
+    if (!resp.ok) {
+      // `.text().catch(() => "")` mirrors the existing vps-client.ts safety
+      // pattern — a body-read failure must not swallow the original status.
+      const text = await resp.text().catch(() => "");
+      throw new GroqTranscribeError(resp.status, text);
     }
-    throw new GroqTranscribeError(
-      "network",
-      err instanceof Error ? err.message : String(err)
-    );
-  }
 
-  if (!resp.ok) {
-    // `.text().catch(() => "")` mirrors the existing vps-client.ts safety
-    // pattern — a body-read failure must not swallow the original status.
-    const text = await resp.text().catch(() => "");
-    throw new GroqTranscribeError(resp.status, text);
-  }
+    let raw: unknown;
+    try {
+      raw = await resp.json();
+    } catch (err) {
+      throw new GroqTranscribeError(
+        "schema",
+        `JSON parse: ${err instanceof Error ? err.message : err}`
+      );
+    }
 
-  let raw: unknown;
-  try {
-    raw = await resp.json();
-  } catch (err) {
-    throw new GroqTranscribeError(
-      "schema",
-      `JSON parse: ${err instanceof Error ? err.message : err}`
-    );
-  }
+    const parsed = GroqResponseSchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new GroqTranscribeError("schema", parsed.error.message);
+    }
 
-  const parsed = GroqResponseSchema.safeParse(raw);
-  if (!parsed.success) {
-    throw new GroqTranscribeError("schema", parsed.error.message);
+    // Drop empty / whitespace-only segments (Groq occasionally emits a
+    // trailing empty-text segment for end-of-audio silence — same defensive
+    // behavior parseWhisperJson already applies).
+    const segments: TranscriptSegment[] = [];
+    for (const s of parsed.data.segments) {
+      const text = s.text.trim();
+      if (!text) continue;
+      segments.push({
+        text,
+        start: s.start,
+        duration: Math.max(0, s.end - s.start),
+      });
+    }
+    // Return empty segments verbatim — the route's existing length check
+    // handles "no usable content" identically for both this backend and
+    // the local-Whisper fallback path (WHISPER_EMPTY_RESULT). Throwing
+    // here would break that symmetry by routing the response through the
+    // Groq-failure catch (fallback / 503) instead of the cleaner 500 +
+    // "Transcription produced no content."
+    return { segments, language: parsed.data.language ?? lang ?? "auto" };
+  } finally {
+    await cleanupCompressed(uploadPath);
   }
-
-  // Drop empty / whitespace-only segments (Groq occasionally emits a
-  // trailing empty-text segment for end-of-audio silence — same defensive
-  // behavior parseWhisperJson already applies).
-  const segments: TranscriptSegment[] = [];
-  for (const s of parsed.data.segments) {
-    const text = s.text.trim();
-    if (!text) continue;
-    segments.push({
-      text,
-      start: s.start,
-      duration: Math.max(0, s.end - s.start),
-    });
-  }
-  // Return empty segments verbatim — the route's existing length check
-  // handles "no usable content" identically for both this backend and
-  // the local-Whisper fallback path (WHISPER_EMPTY_RESULT). Throwing
-  // here would break that symmetry by routing the response through the
-  // Groq-failure catch (fallback / 503) instead of the cleaner 500 +
-  // "Transcription produced no content."
-  return { segments, language: parsed.data.language ?? lang ?? "auto" };
 }


### PR DESCRIPTION
## Summary
- The 28-min repro URL `D-dRD6zCpbY` hit the new Groq path after PR #15 deployed and failed at +117.8s with the generic "Couldn't process this video" error.
- Root cause: yt-dlp's `--audio-quality 0` mp3 averages ~245 kbps VBR, producing a ~50 MB file for 28 minutes. Groq's free-tier audio transcription endpoint caps uploads at **25 MB** → 413, route probes audio length (1680 s) > `GROQ_LOCAL_FALLBACK_MAX_SECONDS` (180), returns 503 `GROQ_FAILED_NO_FALLBACK`, frontend surfaces the generic error.
- Fix: Add `compressForGroq` that re-encodes to **16 kHz mono 32 kbps mp3** via ffmpeg before the upload. Whisper trains at 16 kHz mono so the downsample is loss-free for transcription accuracy; 32 kbps shrinks the upload by ~7× (≈ 6.7 MB / 28 min, ≈ 24 MB / 100 min) — fits Groq's 25 MB cap for the vast majority of YouTube content.
- The original file stays untouched, so the local-Whisper fallback path is unaffected.

## Error handling
- ffmpeg failures throw `GroqTranscribeError(status="compress")` so the route's existing catch applies the same rules as a Groq 5xx — fall back to local Whisper iff `audio ≤ GROQ_LOCAL_FALLBACK_MAX_SECONDS`, else 503.
- Cleanup of the temp compressed file runs in a `finally` so it disappears even on the unhappy path. Cleanup is **not** called when compression itself fails (no file was produced).

## Test plan
- [x] `npm test` — 243/243 passing (4 new groq-transcribe tests + 3 new audio-compress tests)
- [x] `npm run build` — clean
- [ ] Post-deploy: re-run `https://www.youtubeai.chat/summary?url=…D-dRD6zCpbY` → expect a real summary, transcribe_time < 60s
- [ ] Post-deploy: sanity-check a captioned video doesn't go through Groq (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)