### PR TITLE
fix(transcribe): no local-Whisper fallback when Groq is rate-limited

### DIFF
--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -297,39 +297,42 @@ describe("POST /transcribe — Groq orchestration", () => {
     );
   });
 
-  it("returns 503 when Groq returns 429 (rate-limited), regardless of audio length — no local fallback for quota exhaustion", async () => {
-    // Quota exhaustion is the one Groq failure mode we deliberately do
-    // NOT mask via local Whisper. The in-process retry inside
-    // groq-transcribe.ts has already covered transient per-minute blips
-    // by the time we see this error, so 429 here means the quota is
-    // genuinely out and the user should see a transcription error
-    // rather than a silently-slower local-Whisper summary.
-    vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
-      new GroqTranscribeError(429, "rate limited")
-    );
-    vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(60);
-    const localSpy = vi.spyOn(whisperLib, "transcribeAudio");
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  it.each([60, 900])(
+    "returns 503 when Groq returns 429 (rate-limited) at audio=%ds — no local fallback for quota exhaustion",
+    async (audioSeconds) => {
+      // Quota exhaustion is the one Groq failure mode we deliberately do
+      // NOT mask via local Whisper. The in-process retry inside
+      // groq-transcribe.ts has already covered transient per-minute blips
+      // by the time we see this error, so 429 here means the quota is
+      // genuinely out and the user should see a transcription error
+      // rather than a silently-slower local-Whisper summary.
+      vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
+        new GroqTranscribeError(429, "rate limited")
+      );
+      vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(audioSeconds);
+      const localSpy = vi.spyOn(whisperLib, "transcribeAudio");
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    const res = await post({
-      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-    });
+      const res = await post({
+        youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      });
 
-    expect(res.status).toBe(503);
-    expect(localSpy).not.toHaveBeenCalled();
-    const body = await res.json();
-    expect(body.error).toMatch(/temporarily unavailable/i);
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("GROQ_FAILED_NO_FALLBACK"),
-      expect.objectContaining({
-        errorId: "GROQ_FAILED_NO_FALLBACK",
-        audioSeconds: 60,
-        fallbackCap: 180,
-        groqStatus: 429,
-      })
-    );
-    expect(ytdlpLib.cleanupAudio).toHaveBeenCalledWith("/tmp/fake.mp3");
-  });
+      expect(res.status).toBe(503);
+      expect(localSpy).not.toHaveBeenCalled();
+      const body = await res.json();
+      expect(body.error).toMatch(/temporarily unavailable/i);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("GROQ_FAILED_NO_FALLBACK"),
+        expect.objectContaining({
+          errorId: "GROQ_FAILED_NO_FALLBACK",
+          audioSeconds,
+          fallbackCap: 180,
+          groqStatus: 429,
+        })
+      );
+      expect(ytdlpLib.cleanupAudio).toHaveBeenCalledWith("/tmp/fake.mp3");
+    }
+  );
 
   it("returns 503 when Groq fails and audio > fallback cap (no local attempt)", async () => {
     vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(

--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -297,6 +297,40 @@ describe("POST /transcribe — Groq orchestration", () => {
     );
   });
 
+  it("returns 503 when Groq returns 429 (rate-limited), regardless of audio length — no local fallback for quota exhaustion", async () => {
+    // Quota exhaustion is the one Groq failure mode we deliberately do
+    // NOT mask via local Whisper. The in-process retry inside
+    // groq-transcribe.ts has already covered transient per-minute blips
+    // by the time we see this error, so 429 here means the quota is
+    // genuinely out and the user should see a transcription error
+    // rather than a silently-slower local-Whisper summary.
+    vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
+      new GroqTranscribeError(429, "rate limited")
+    );
+    vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(60);
+    const localSpy = vi.spyOn(whisperLib, "transcribeAudio");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    expect(res.status).toBe(503);
+    expect(localSpy).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.error).toMatch(/temporarily unavailable/i);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("GROQ_FAILED_NO_FALLBACK"),
+      expect.objectContaining({
+        errorId: "GROQ_FAILED_NO_FALLBACK",
+        audioSeconds: 60,
+        fallbackCap: 180,
+        groqStatus: 429,
+      })
+    );
+    expect(ytdlpLib.cleanupAudio).toHaveBeenCalledWith("/tmp/fake.mp3");
+  });
+
   it("returns 503 when Groq fails and audio > fallback cap (no local attempt)", async () => {
     vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
       new GroqTranscribeError("network", "ECONNRESET")

--- a/src/routes/transcribe.ts
+++ b/src/routes/transcribe.ts
@@ -91,12 +91,21 @@ transcribe.post("/", async (c) => {
         const audioSeconds = await probeAudioDurationSeconds(audioPath);
         const fallbackCap =
           Number(process.env.GROQ_LOCAL_FALLBACK_MAX_SECONDS) || 180;
+        // Quota exhaustion is the one Groq failure we deliberately surface as
+        // an error rather than mask with local Whisper. groq-transcribe.ts
+        // already retries 429 once with a 2 s backoff, so reaching this branch
+        // means Groq's quota is genuinely out — silent degradation here would
+        // hide the operational signal and turn a "transcription unavailable"
+        // event into "the site got slow today."
+        const isRateLimited = err.status === 429;
         // audioSeconds === null means ffprobe failed; fail closed (treat
         // as "too long for fallback") so a noisy probe doesn't promote
         // a routine Groq blip into a multi-minute local-Whisper attempt
         // for a video we can't bound.
         const eligibleForFallback =
-          audioSeconds !== null && audioSeconds <= fallbackCap;
+          !isRateLimited &&
+          audioSeconds !== null &&
+          audioSeconds <= fallbackCap;
 
         if (eligibleForFallback) {
           console.warn(


### PR DESCRIPTION
## Summary
- When Groq returns 429 (post-retry — quota genuinely out), skip the local-Whisper fallback and surface the existing generic transcription error to the user.
- Existing in-process retry on 429 in `groq-transcribe.ts` (one retry after 2 s) covers transient blips, so this branch only fires on genuine quota exhaustion.
- One-line predicate change in `routes/transcribe.ts`. No frontend change. No new env vars, error types, or response fields.

## Why
The current behavior masks Groq quota exhaustion as a slower path: short videos transparently use local Whisper (30 s – 2 min) instead of Groq (~5 s). The user perceives "the site is slow today," and the operator only sees the signal as `GROQ_FALLBACK` lines in container logs that nobody actively tails. Failing the request explicitly turns both into one observable event — generic user error + existing `GROQ_FAILED_NO_FALLBACK` log with `groqStatus: 429`.

## Test plan
- [x] New unit test: short video + Groq 429 → 503, no local-Whisper call, error log carries `groqStatus: 429`
- [x] Regression: short video + Groq 500 → still 200 with local fallback
- [x] Regression: long video + Groq 429 → still 503 (path through predicate differs; result identical)
- [x] `npm test` — full suite passes (251 tests)
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)