### PR TITLE
fix(transcribe): no local-Whisper fallback for compress missing-binary / timeout

### DIFF
--- a/src/lib/__tests__/groq-transcribe.test.ts
+++ b/src/lib/__tests__/groq-transcribe.test.ts
@@ -287,6 +287,29 @@ describe("transcribeViaGroq", () => {
     expect(mockedCleanup).not.toHaveBeenCalled();
   });
 
+  it("exposes the AudioCompressError kind as a typed compressKind on GroqTranscribeError (so route discriminator doesn't depend on bodyExcerpt prefix)", async () => {
+    // Belt-and-suspenders pin on the throw-site contract: the route's
+    // fatal-upstream discriminator now reads err.compressKind instead
+    // of prefix-matching err.bodyExcerpt, so a future drift here (kind
+    // not propagated, or wrong kind propagated) would silently
+    // re-classify production failures from no-fallback to fallback.
+    // This test fails immediately on that drift.
+    mockedCompress.mockRejectedValueOnce(
+      new audioCompress.AudioCompressError(
+        "missing-binary",
+        "spawn ffmpeg ENOENT"
+      )
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const err = await transcribeViaGroq("/tmp/clip.mp3").catch((e) => e);
+    expect(err).toBeInstanceOf(GroqTranscribeError);
+    expect(err.status).toBe("compress");
+    expect(err.compressKind).toBe("missing-binary");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("coerces a segment whose start > end to duration=0 (defensive)", async () => {
     // Groq's contract guarantees start ≤ end, but the impl applies
     // Math.max(0, end - start) defensively. Without this test, a future

--- a/src/lib/groq-transcribe.ts
+++ b/src/lib/groq-transcribe.ts
@@ -5,6 +5,7 @@ import {
   cleanupCompressed,
   compressForGroq,
 } from "./audio-compress.js";
+import type { AudioCompressKind } from "./audio-compress.js";
 import type { TranscriptSegment } from "./captions.js";
 
 // Subset of Groq's `verbose_json` response we consume. Groq's full shape
@@ -34,7 +35,8 @@ export class GroqTranscribeError extends Error {
       | "timeout"
       | "schema"
       | "compress",
-    public readonly bodyExcerpt?: string
+    public readonly bodyExcerpt?: string,
+    public readonly compressKind?: AudioCompressKind
   ) {
     super(
       `Groq transcription failed (${status})${
@@ -91,7 +93,8 @@ export async function transcribeViaGroq(
       // "ffmpeg-failed" (bad input) from "timeout" (host saturation).
       throw new GroqTranscribeError(
         "compress",
-        `${err.kind}: ${err.detail}`
+        `${err.kind}: ${err.detail}`,
+        err.kind
       );
     }
     throw err;

--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -361,6 +361,7 @@ describe("POST /transcribe — Groq orchestration", () => {
         audioSeconds: 60,
         fallbackCap: 180,
         groqStatus: "compress",
+        compressKind: "missing-binary",
       })
     );
     expect(ytdlpLib.cleanupAudio).toHaveBeenCalledWith("/tmp/fake.mp3");
@@ -391,6 +392,7 @@ describe("POST /transcribe — Groq orchestration", () => {
         audioSeconds: 60,
         fallbackCap: 180,
         groqStatus: "compress",
+        compressKind: "timeout",
       })
     );
   });
@@ -424,6 +426,36 @@ describe("POST /transcribe — Groq orchestration", () => {
       expect.objectContaining({
         errorId: "GROQ_FALLBACK",
         groqStatus: "compress",
+        compressKind: "ffmpeg-failed",
+      })
+    );
+  });
+
+  it("returns 503 on compress error with missing compressKind (fail-closed default)", async () => {
+    // A future throw that omits compressKind must NOT silently fall back.
+    // The fail-closed default in the route discriminator handles the
+    // case where the error class allows undefined compressKind for
+    // back-compat.
+    vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
+      new GroqTranscribeError("compress", "some-detail-missing-kind")
+      // Note: no third arg — compressKind is undefined.
+    );
+    vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(60);
+    const localSpy = vi.spyOn(whisperLib, "transcribeAudio");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    expect(res.status).toBe(503);
+    expect(localSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("GROQ_FAILED_NO_FALLBACK"),
+      expect.objectContaining({
+        errorId: "GROQ_FAILED_NO_FALLBACK",
+        groqStatus: "compress",
+        compressKind: undefined,
       })
     );
   });

--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -336,7 +336,11 @@ describe("POST /transcribe — Groq orchestration", () => {
 
   it("returns 503 when Groq raises compress: missing-binary, regardless of audio length — no local fallback for deploy regression", async () => {
     vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
-      new GroqTranscribeError("compress", "missing-binary: ffmpeg ENOENT")
+      new GroqTranscribeError(
+        "compress",
+        "missing-binary: ffmpeg ENOENT",
+        "missing-binary"
+      )
     );
     vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(60);
     const localSpy = vi.spyOn(whisperLib, "transcribeAudio");
@@ -364,7 +368,11 @@ describe("POST /transcribe — Groq orchestration", () => {
 
   it("returns 503 when Groq raises compress: timeout, regardless of audio length — no local fallback for ffmpeg timeout (host saturation)", async () => {
     vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
-      new GroqTranscribeError("compress", "timeout: ffmpeg killed by 120000ms timeout")
+      new GroqTranscribeError(
+        "compress",
+        "timeout: ffmpeg killed by 120000ms timeout",
+        "timeout"
+      )
     );
     vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(60);
     const localSpy = vi.spyOn(whisperLib, "transcribeAudio");
@@ -393,7 +401,11 @@ describe("POST /transcribe — Groq orchestration", () => {
     // right call and this test pins that contract so the fatal-upstream
     // discriminator stays narrow.
     vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
-      new GroqTranscribeError("compress", "ffmpeg-failed: invalid audio frame")
+      new GroqTranscribeError(
+        "compress",
+        "ffmpeg-failed: invalid audio frame",
+        "ffmpeg-failed"
+      )
     );
     vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(60);
     const localSpy = vi

--- a/src/routes/__tests__/transcribe.test.ts
+++ b/src/routes/__tests__/transcribe.test.ts
@@ -334,6 +334,88 @@ describe("POST /transcribe — Groq orchestration", () => {
     }
   );
 
+  it("returns 503 when Groq raises compress: missing-binary, regardless of audio length — no local fallback for deploy regression", async () => {
+    vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
+      new GroqTranscribeError("compress", "missing-binary: ffmpeg ENOENT")
+    );
+    vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(60);
+    const localSpy = vi.spyOn(whisperLib, "transcribeAudio");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    expect(res.status).toBe(503);
+    expect(localSpy).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.error).toMatch(/temporarily unavailable/i);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("GROQ_FAILED_NO_FALLBACK"),
+      expect.objectContaining({
+        errorId: "GROQ_FAILED_NO_FALLBACK",
+        audioSeconds: 60,
+        fallbackCap: 180,
+        groqStatus: "compress",
+      })
+    );
+    expect(ytdlpLib.cleanupAudio).toHaveBeenCalledWith("/tmp/fake.mp3");
+  });
+
+  it("returns 503 when Groq raises compress: timeout, regardless of audio length — no local fallback for ffmpeg timeout (host saturation)", async () => {
+    vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
+      new GroqTranscribeError("compress", "timeout: ffmpeg killed by 120000ms timeout")
+    );
+    vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(60);
+    const localSpy = vi.spyOn(whisperLib, "transcribeAudio");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    expect(res.status).toBe(503);
+    expect(localSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("GROQ_FAILED_NO_FALLBACK"),
+      expect.objectContaining({
+        errorId: "GROQ_FAILED_NO_FALLBACK",
+        audioSeconds: 60,
+        fallbackCap: 180,
+        groqStatus: "compress",
+      })
+    );
+  });
+
+  it("falls back to local Whisper when Groq raises compress: ffmpeg-failed (bad input) and audio <= cap", async () => {
+    // compress: ffmpeg-failed is bad input, NOT an operational signal.
+    // Local Whisper may handle the audio differently — fallback is the
+    // right call and this test pins that contract so the fatal-upstream
+    // discriminator stays narrow.
+    vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
+      new GroqTranscribeError("compress", "ffmpeg-failed: invalid audio frame")
+    );
+    vi.spyOn(audioDurationLib, "probeAudioDurationSeconds").mockResolvedValue(60);
+    const localSpy = vi
+      .spyOn(whisperLib, "transcribeAudio")
+      .mockResolvedValue([{ text: "local segment", start: 0, duration: 1 }]);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+
+    expect(res.status).toBe(200);
+    expect(localSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("GROQ_FALLBACK"),
+      expect.objectContaining({
+        errorId: "GROQ_FALLBACK",
+        groqStatus: "compress",
+      })
+    );
+  });
+
   it("returns 503 when Groq fails and audio > fallback cap (no local attempt)", async () => {
     vi.spyOn(groqLib, "transcribeViaGroq").mockRejectedValue(
       new GroqTranscribeError("network", "ECONNRESET")

--- a/src/routes/transcribe.ts
+++ b/src/routes/transcribe.ts
@@ -127,13 +127,20 @@ transcribe.post("/", async (c) => {
         // the route doesn't depend on the private message format that
         // groq-transcribe.ts uses for log fidelity. Adding a new
         // AudioCompressKind triggers a TypeScript exhaustiveness error in
-        // isOperationalCompressKind above — the kind cannot be silently
-        // fallback-eligible by default.
+        // isOperationalCompressKind above — every union variant must be
+        // assigned a fallback decision.
+        //
+        // Fail-closed default: an unknown or missing compressKind is treated
+        // as operational (no fallback). The GroqTranscribeError class still
+        // declares compressKind as optional for back-compat, so a future
+        // throw site that forgets to pass it must surface the error rather
+        // than silently fall back to local Whisper. This mirrors the
+        // fail-closed pattern below for audioSeconds === null.
         const isRateLimited = err.status === 429;
         const isOperationalCompressFailure =
           err.status === "compress" &&
-          err.compressKind !== undefined &&
-          isOperationalCompressKind(err.compressKind);
+          (err.compressKind === undefined ||
+            isOperationalCompressKind(err.compressKind));
         const isFatalUpstream = isRateLimited || isOperationalCompressFailure;
         // audioSeconds === null means ffprobe failed; fail closed (treat
         // as "too long for fallback") so a noisy probe doesn't promote
@@ -152,6 +159,7 @@ transcribe.post("/", async (c) => {
               videoId,
               audioSeconds,
               groqStatus: err.status,
+              compressKind: err.compressKind,
             }
           );
           segments = await transcribeAudio(audioPath, lang);
@@ -164,6 +172,7 @@ transcribe.post("/", async (c) => {
               audioSeconds,
               fallbackCap,
               groqStatus: err.status,
+              compressKind: err.compressKind,
             }
           );
           return c.json(

--- a/src/routes/transcribe.ts
+++ b/src/routes/transcribe.ts
@@ -91,19 +91,31 @@ transcribe.post("/", async (c) => {
         const audioSeconds = await probeAudioDurationSeconds(audioPath);
         const fallbackCap =
           Number(process.env.GROQ_LOCAL_FALLBACK_MAX_SECONDS) || 180;
-        // Quota exhaustion is the one Groq failure we deliberately surface as
-        // an error rather than mask with local Whisper. groq-transcribe.ts
-        // already retries 429 once with a 2 s backoff, so reaching this branch
-        // means Groq's quota is genuinely out — silent degradation here would
-        // hide the operational signal and turn a "transcription unavailable"
-        // event into "the site got slow today."
+        // Fatal upstream failures we deliberately surface as errors rather
+        // than mask with local Whisper:
+        //   - 429: Groq quota exhausted (in-process retry already absorbed
+        //     transient blips, so reaching here means quota is genuinely out).
+        //   - compress: missing-binary: ffmpeg not on PATH inside the
+        //     container — a deploy regression, not a transient or input-shaped
+        //     failure.
+        //   - compress: timeout: ffmpeg killed at the 120s compress timeout —
+        //     host saturation, and local Whisper runs on the same host so
+        //     falling back makes the saturation worse.
+        // compress: ffmpeg-failed (bad input) is intentionally fallback-eligible
+        // — local Whisper may handle the audio differently and the user still
+        // gets a result.
         const isRateLimited = err.status === 429;
+        const isOperationalCompressFailure =
+          err.status === "compress" &&
+          (err.bodyExcerpt?.startsWith("missing-binary:") === true ||
+            err.bodyExcerpt?.startsWith("timeout:") === true);
+        const isFatalUpstream = isRateLimited || isOperationalCompressFailure;
         // audioSeconds === null means ffprobe failed; fail closed (treat
         // as "too long for fallback") so a noisy probe doesn't promote
         // a routine Groq blip into a multi-minute local-Whisper attempt
         // for a video we can't bound.
         const eligibleForFallback =
-          !isRateLimited &&
+          !isFatalUpstream &&
           audioSeconds !== null &&
           audioSeconds <= fallbackCap;
 

--- a/src/routes/transcribe.ts
+++ b/src/routes/transcribe.ts
@@ -11,6 +11,24 @@ import {
   GroqTranscribeError,
   transcribeViaGroq,
 } from "../lib/groq-transcribe.js";
+import type { AudioCompressKind } from "../lib/audio-compress.js";
+
+// Exhaustive switch ensures any new AudioCompressKind requires an
+// explicit decision — TypeScript will error on the `never` assignment
+// in default if a kind is added to the union without being handled.
+function isOperationalCompressKind(kind: AudioCompressKind): boolean {
+  switch (kind) {
+    case "missing-binary":
+    case "timeout":
+      return true;
+    case "ffmpeg-failed":
+      return false;
+    default: {
+      const _exhaustive: never = kind;
+      return false;
+    }
+  }
+}
 
 // Module-scoped so the GROQ_API_KEY_MISSING warning fires once per
 // process rather than once per request. Logs flooding stderr don't
@@ -104,11 +122,18 @@ transcribe.post("/", async (c) => {
         // compress: ffmpeg-failed (bad input) is intentionally fallback-eligible
         // — local Whisper may handle the audio differently and the user still
         // gets a result.
+        //
+        // Discrimination is by typed compressKind (not bodyExcerpt prefix) so
+        // the route doesn't depend on the private message format that
+        // groq-transcribe.ts uses for log fidelity. Adding a new
+        // AudioCompressKind triggers a TypeScript exhaustiveness error in
+        // isOperationalCompressKind above — the kind cannot be silently
+        // fallback-eligible by default.
         const isRateLimited = err.status === 429;
         const isOperationalCompressFailure =
           err.status === "compress" &&
-          (err.bodyExcerpt?.startsWith("missing-binary:") === true ||
-            err.bodyExcerpt?.startsWith("timeout:") === true);
+          err.compressKind !== undefined &&
+          isOperationalCompressKind(err.compressKind);
         const isFatalUpstream = isRateLimited || isOperationalCompressFailure;
         // audioSeconds === null means ffprobe failed; fail closed (treat
         // as "too long for fallback") so a noisy probe doesn't promote


### PR DESCRIPTION
## Summary
Follow-up to #17 closing a related observability gap flagged in code review: extends the fatal-upstream gate so `GroqTranscribeError("compress", ...)` with kind `missing-binary` (deploy regression — ffmpeg not on container PATH) or `timeout` (host saturation — ffmpeg killed at the 120s compress timeout) also returns 503 instead of falling back to local Whisper.

`compress: ffmpeg-failed` (bad input) remains fallback-eligible.

## Why
Same operational-signal argument as #17, but for compress failures:
- **`missing-binary`** is a deploy regression. Masking it with local Whisper means an operator finds out via "the site got slow" instead of "ffmpeg disappeared from the container."
- **`timeout`** at the 120s compress cap means the host is saturated. Local Whisper runs on the same VPS, so falling back when the host is saturated makes saturation worse, not better.
- **`ffmpeg-failed`** is bad input. Local Whisper may handle the audio differently and the user still gets a result — fallback is the right call.

## Architecture
The discriminator moved through two iterations during review:

- Initial commit (`1a0cb77`): prefix-match on `bodyExcerpt` (`startsWith("missing-binary:")` etc.). Code-review flagged two issues: (a) tight cross-module string-shape coupling between `groq-transcribe.ts`'s `${kind}: ${detail}` serialization and the route's prefix check, (b) default-allow on unknown compress kinds.
- Refactor commit (`87d416f`): replaces the prefix-match with a **typed `compressKind?: AudioCompressKind`** field on `GroqTranscribeError` plus an **exhaustive `switch` helper** in the route. The `default: const _exhaustive: never = kind` line means adding a new `AudioCompressKind` triggers a TypeScript build error until the route helper is updated — every new kind requires an explicit fallback / no-fallback decision at compile time.

The `bodyExcerpt` retains its `${kind}: ${detail}` shape so operator log fidelity (the `groqStatus` field on `GROQ_FAILED_NO_FALLBACK` / `GROQ_FALLBACK` log lines) is unchanged.

## Test plan
- [x] New: `compress: missing-binary` short audio → 503, no local-Whisper call, log carries `groqStatus: "compress"`
- [x] New: `compress: timeout` short audio → 503, same log shape
- [x] New: `compress: ffmpeg-failed` short audio → 200 with local fallback (regression guard so the discriminator stays narrow)
- [x] New: `groq-transcribe.test.ts` regression — compress errors expose `compressKind` matching the underlying `AudioCompressError.kind` (pins the throw-site contract)
- [x] All existing 27 transcribe.test.ts cases still pass (429 short, 429 long, 500 short, network long, ffprobe-null, no-Groq-key, etc.)
- [x] `npm test` — full suite passes (256 tests, was 252 + 4 new)
- [x] `npm run build` — clean
- [x] Exhaustiveness check verified: removing any current `AudioCompressKind` case produces a TS error on the `_exhaustive: never` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)