### PR TITLE
chore(deps): zod 4 in service (A1 PR 3/5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "franc": "^6.2.0",
         "hono": "^4.6.0",
         "youtube-transcript-plus": "^2.0.0",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -1748,9 +1748,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "franc": "^6.2.0",
     "hono": "^4.6.0",
     "youtube-transcript-plus": "^2.0.0",
-    "zod": "^3.25.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/lib/youtube-url.ts
+++ b/src/lib/youtube-url.ts
@@ -29,7 +29,6 @@ export function isYoutubeUrl(url: string): boolean {
 }
 
 export const youtubeUrlSchema = z
-  .string()
   .url()
   .refine(isYoutubeUrl, {
     message: "URL must be a YouTube URL",


### PR DESCRIPTION
## Summary
- Bumps `zod` 3.25.x → 4.3.6 in `youtube-ai-service`
- Migrates the deprecated `z.string().url()` chain in `youtubeUrlSchema` to the new top-level `z.url()` factory

Part of A1 dependency modernization (frontend repo PR 3/5). Coordinated with the frontend zod 4 PR: https://github.com/xtan9/youtubeai_chat_frontend/pull/51 — both ship together to avoid a transient state where the frontend and VPS speak different validator versions over the wire.

Spec: `youtubeai_chat_frontend/docs/superpowers/specs/2026-04-27-deps-modernization-a1-design.md`

## Migration scope
zod 4 is largely back-compat for our usage:
- `.refine()`, `.regex()`, `.safeParse()`, `z.array()`, `z.object()`, `z.literal()`, `.optional()` all work unchanged
- `parsed.error.flatten()` (used by /captions, /transcribe, /metadata 400 responses) is deprecated for `z.treeifyError()` but still works identically; preserved to keep the wire shape byte-identical for the frontend that consumes those error bodies

Only the `z.string().url()` → `z.url()` migration was applied per the spec's explicit guidance.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 257/257 vitest tests pass
- [x] `npm run build` (tsc) clean
- [ ] CI green