### PR TITLE
fix(transcribe): anchor whisper to target language to stop drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .env
 .env.local
 *.log
+.worktrees/

--- a/src/lib/__tests__/groq-transcribe.test.ts
+++ b/src/lib/__tests__/groq-transcribe.test.ts
@@ -128,6 +128,12 @@ describe("transcribeViaGroq", () => {
     // native-language anchor, not the prior English-default fallback or
     // an empty placeholder.
     expect(prompt as string).toMatch(/[一-鿿]/);
+    // Executable comment: Groq's hosted Whisper does not expose
+    // `condition_on_previous_text`, so we must NOT send a field with
+    // that name. A future engineer might assume it works and silently
+    // bloat the multipart body for no effect — pin the absence so a
+    // copy-paste from the local-Whisper fix can't slip in.
+    expect(formData.get("condition_on_previous_text")).toBeNull();
   });
 
   it("omits `prompt` when no lang is provided (no language to anchor to)", async () => {

--- a/src/lib/__tests__/groq-transcribe.test.ts
+++ b/src/lib/__tests__/groq-transcribe.test.ts
@@ -103,6 +103,62 @@ describe("transcribeViaGroq", () => {
     expect(formData.get("language")).toBeNull();
   });
 
+  it("sends a native-language `prompt` alongside `language` so the model doesn't drift", async () => {
+    // Captured on video hrREdNm7vB4: with only `language=zh`, Groq's
+    // whisper-large-v3-turbo hallucinated English (and French "même")
+    // during non-speech segments and propagated through subsequent
+    // chunks via the model's internal prev-text conditioning. Groq's
+    // hosted Whisper does not expose `condition_on_previous_text`, so
+    // the `prompt` form field is the only available lever — a short
+    // native-language anchor biases the output distribution every chunk
+    // and stops the drift. Test asserts the anchor is non-empty and in
+    // the target language so a future refactor can't drop the field
+    // back to Whisper-default behavior.
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(validGroqBody));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await transcribeViaGroq("/tmp/clip.mp3", "zh");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const formData = init.body as FormData;
+    const prompt = formData.get("prompt");
+    expect(typeof prompt).toBe("string");
+    expect(prompt).toBeTruthy();
+    // Anchor must contain CJK characters when lang=zh — proves it's a
+    // native-language anchor, not the prior English-default fallback or
+    // an empty placeholder.
+    expect(prompt as string).toMatch(/[一-鿿]/);
+  });
+
+  it("omits `prompt` when no lang is provided (no language to anchor to)", async () => {
+    // Without a target language we can't pick an anchor — sending an
+    // English prompt would bias auto-detect toward English, the exact
+    // failure mode we're trying to fix.
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(validGroqBody));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await transcribeViaGroq("/tmp/clip.mp3");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const formData = init.body as FormData;
+    expect(formData.get("prompt")).toBeNull();
+  });
+
+  it("omits `prompt` for a lang we have no anchor for (falls through to language-only pinning)", async () => {
+    // Strictly additive guard: an unknown ISO 639-1 code (Welsh, etc.)
+    // skips the prompt rather than sending a wrong-language anchor that
+    // would actively *cause* the bug we're fixing.
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(validGroqBody));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await transcribeViaGroq("/tmp/clip.mp3", "cy");
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const formData = init.body as FormData;
+    expect(formData.get("language")).toBe("cy");
+    expect(formData.get("prompt")).toBeNull();
+  });
+
   it("retries once on 429 with backoff and succeeds on the second attempt", async () => {
     vi.useFakeTimers();
     const fetchMock = vi

--- a/src/lib/__tests__/language-prompt.test.ts
+++ b/src/lib/__tests__/language-prompt.test.ts
@@ -1,18 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { getLanguageAnchorPrompt } from "../language-prompt.js";
+import { ISO_639_3_TO_1 } from "../language-detect.js";
 
 describe("getLanguageAnchorPrompt", () => {
-  it("returns a non-empty string for every detectLanguage()-returnable code", () => {
-    // detectLanguage() in language-detect.ts can return any value in its
-    // ISO_639_3_TO_1 map plus "en" (final fallback). This test pins the
-    // contract that every such code has an anchor — a missing entry would
-    // silently fall through to flag-only pinning and reintroduce the
-    // hallucination bug for that language.
-    const codes = [
-      "en", "zh", "fr", "es", "ja", "ko", "de", "pt", "ru", "it",
-      "ar", "hi", "nl", "tr", "vi", "id", "th", "pl", "uk", "sv",
-      "da", "no", "fi", "cs", "el", "he", "ro", "hu",
-    ];
+  it("returns a non-empty string for every code detectLanguage() can return", () => {
+    // detectLanguage() emits values from ISO_639_3_TO_1 plus "en" (the
+    // ultimate fallback). Iterating the *imported* map — not a copy —
+    // is the parity guard: a future PR that adds e.g. `tgl: "tl"` to
+    // ISO_639_3_TO_1 without adding `tl` here will fail this test
+    // instead of silently dropping the anchor for that language and
+    // reintroducing the drift bug. A hardcoded list would not catch
+    // that drift.
+    const codes = new Set<string>([...Object.values(ISO_639_3_TO_1), "en"]);
     for (const code of codes) {
       const prompt = getLanguageAnchorPrompt(code);
       expect(prompt, `missing anchor for ${code}`).toBeTruthy();
@@ -34,12 +33,38 @@ describe("getLanguageAnchorPrompt", () => {
     expect(getLanguageAnchorPrompt("  ")).toBeNull();
   });
 
+  it("returns null for normalizeLanguageCode sentinels", () => {
+    // detectLanguage upstream rejects und/zxx/mul/mis at
+    // normalizeLanguageCode and won't pass them down — but a manual VPS
+    // caller could. Pinning null here means a future map edit can't
+    // accidentally wire an anchor to a sentinel code, which would force
+    // a wrong-language anchor onto undetected/no-content audio.
+    expect(getLanguageAnchorPrompt("und")).toBeNull();
+    expect(getLanguageAnchorPrompt("zxx")).toBeNull();
+    expect(getLanguageAnchorPrompt("mul")).toBeNull();
+    expect(getLanguageAnchorPrompt("mis")).toBeNull();
+  });
+
+  it("extracts the primary subtag from BCP-47 input", () => {
+    // VPS schema (`languageCodeSchema` in youtube-url.ts) accepts
+    // BCP-47 directly. The frontend's `primarySubtag` normalizes
+    // before calling, but a direct VPS caller (or a future frontend
+    // bug) could ship `zh-Hans`. Without primary-subtag extraction
+    // here, that case silently skips the anchor and reintroduces the
+    // drift bug for the dominant Chinese variant.
+    const zh = getLanguageAnchorPrompt("zh");
+    expect(getLanguageAnchorPrompt("zh-Hans")).toEqual(zh);
+    expect(getLanguageAnchorPrompt("zh-Hant-TW")).toEqual(zh);
+    expect(getLanguageAnchorPrompt("en-US")).toEqual(getLanguageAnchorPrompt("en"));
+  });
+
   it("is case-insensitive", () => {
     // Callers normalize to lowercase but a stray ZH or Zh shouldn't
     // silently fall through to null and break the fix for those
     // call sites.
     expect(getLanguageAnchorPrompt("ZH")).toEqual(getLanguageAnchorPrompt("zh"));
     expect(getLanguageAnchorPrompt("Zh")).toEqual(getLanguageAnchorPrompt("zh"));
+    expect(getLanguageAnchorPrompt("ZH-HANS")).toEqual(getLanguageAnchorPrompt("zh"));
   });
 
   it("zh anchor contains CJK characters", () => {

--- a/src/lib/__tests__/language-prompt.test.ts
+++ b/src/lib/__tests__/language-prompt.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { getLanguageAnchorPrompt } from "../language-prompt.js";
+
+describe("getLanguageAnchorPrompt", () => {
+  it("returns a non-empty string for every detectLanguage()-returnable code", () => {
+    // detectLanguage() in language-detect.ts can return any value in its
+    // ISO_639_3_TO_1 map plus "en" (final fallback). This test pins the
+    // contract that every such code has an anchor — a missing entry would
+    // silently fall through to flag-only pinning and reintroduce the
+    // hallucination bug for that language.
+    const codes = [
+      "en", "zh", "fr", "es", "ja", "ko", "de", "pt", "ru", "it",
+      "ar", "hi", "nl", "tr", "vi", "id", "th", "pl", "uk", "sv",
+      "da", "no", "fi", "cs", "el", "he", "ro", "hu",
+    ];
+    for (const code of codes) {
+      const prompt = getLanguageAnchorPrompt(code);
+      expect(prompt, `missing anchor for ${code}`).toBeTruthy();
+      expect(prompt!.length).toBeGreaterThan(5);
+    }
+  });
+
+  it("returns null for unknown codes (caller falls through to flag-only pinning)", () => {
+    // Welsh — valid ISO 639-1 but not in our map. Returning null lets
+    // the caller decide; sending a wrong-language anchor would actively
+    // reintroduce the drift bug.
+    expect(getLanguageAnchorPrompt("cy")).toBeNull();
+  });
+
+  it("returns null for null/undefined/empty inputs", () => {
+    expect(getLanguageAnchorPrompt(null)).toBeNull();
+    expect(getLanguageAnchorPrompt(undefined)).toBeNull();
+    expect(getLanguageAnchorPrompt("")).toBeNull();
+    expect(getLanguageAnchorPrompt("  ")).toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    // Callers normalize to lowercase but a stray ZH or Zh shouldn't
+    // silently fall through to null and break the fix for those
+    // call sites.
+    expect(getLanguageAnchorPrompt("ZH")).toEqual(getLanguageAnchorPrompt("zh"));
+    expect(getLanguageAnchorPrompt("Zh")).toEqual(getLanguageAnchorPrompt("zh"));
+  });
+
+  it("zh anchor contains CJK characters", () => {
+    // Sanity: catches the bug where someone "fixes" an encoding issue
+    // by replacing CJK chars with English placeholders — that would
+    // make the anchor *cause* the drift bug instead of preventing it.
+    const prompt = getLanguageAnchorPrompt("zh");
+    expect(prompt).toMatch(/[一-鿿]/);
+  });
+
+  it("ja anchor contains Japanese script", () => {
+    const prompt = getLanguageAnchorPrompt("ja");
+    // Hiragana, katakana, or kanji block — at least one must be present.
+    expect(prompt).toMatch(/[぀-ゟ゠-ヿ一-鿿]/);
+  });
+
+  it("ko anchor contains Hangul", () => {
+    const prompt = getLanguageAnchorPrompt("ko");
+    expect(prompt).toMatch(/[가-힯]/);
+  });
+
+  it("ar anchor contains Arabic script", () => {
+    const prompt = getLanguageAnchorPrompt("ar");
+    expect(prompt).toMatch(/[؀-ۿ]/);
+  });
+});

--- a/src/lib/__tests__/whisper.test.ts
+++ b/src/lib/__tests__/whisper.test.ts
@@ -112,7 +112,12 @@ describe("buildWhisperArgs", () => {
     // wrong-language anchor would actively reintroduce the drift.
     const args = buildWhisperArgs("/tmp/audio.mp3", "cy");
     expect(args).toContain("--language");
-    expect(args.indexOf("--condition_on_previous_text")).toBeGreaterThan(-1);
+    const condIdx = args.indexOf("--condition_on_previous_text");
+    expect(condIdx).toBeGreaterThan(-1);
+    // Pin the value, not just the flag — a regression that flipped this
+    // to "True" would still satisfy a presence-only check while
+    // re-enabling the drift propagation.
+    expect(args[condIdx + 1]).toBe("False");
     expect(args).not.toContain("--initial_prompt");
   });
 });

--- a/src/lib/__tests__/whisper.test.ts
+++ b/src/lib/__tests__/whisper.test.ts
@@ -96,10 +96,12 @@ describe("buildWhisperArgs", () => {
 
   it("omits both drift mitigations when no lang is provided (back-compat)", () => {
     // Callers that don't pass a lang must see the same argv they
-    // always have, so whisper's auto-detect runs unmodified. A stray
-    // condition_on_previous_text=False on the no-lang path would
-    // change behaviour for legitimately mixed-language clips that this
-    // PR isn't trying to address.
+    // always have, so whisper's auto-detect runs unmodified. Without a
+    // pinned target language there's nothing for the model to drift
+    // *away from* — the failure mode this PR addresses doesn't exist
+    // on the no-lang path, and keeping auto-detect's defaults intact
+    // avoids changing behavior for callers that never opted into a
+    // language hint in the first place.
     const args = buildWhisperArgs("/tmp/audio.mp3");
     expect(args).not.toContain("--condition_on_previous_text");
     expect(args).not.toContain("--initial_prompt");

--- a/src/lib/__tests__/whisper.test.ts
+++ b/src/lib/__tests__/whisper.test.ts
@@ -62,6 +62,59 @@ describe("buildWhisperArgs", () => {
     const langIdx = args.indexOf("--language");
     expect(args[langIdx + 1]).toBe("zh");
   });
+
+  it("disables --condition_on_previous_text when a lang is pinned (stops drift propagation)", () => {
+    // The default is True, which carries forward the previous chunk's
+    // output as context for the next. When whisper hallucinates a
+    // wrong-language token in a non-speech window it propagates through
+    // subsequent chunks until strong native audio resets it — the bug
+    // captured on video hrREdNm7vB4 (Chinese audio, ~46% of segments
+    // hallucinated as English with `--language zh` already pinned).
+    // Setting it to False makes each window independent so a single
+    // bad chunk can't cascade.
+    const args = buildWhisperArgs("/tmp/audio.mp3", "zh");
+    const idx = args.indexOf("--condition_on_previous_text");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("False");
+  });
+
+  it("emits --initial_prompt with a native-language anchor when lang is pinned", () => {
+    // Whisper's `--language` flag tells the model what to transcribe
+    // *to*, but doesn't bias output distribution chunk-by-chunk. A
+    // short native-language anchor in the prompt does — the
+    // belt-and-braces fix to the same drift problem the
+    // condition_on_previous_text=False guard handles. Asserting the
+    // anchor is non-empty and contains CJK chars for zh proves it's a
+    // real native-language anchor, not a stray English default.
+    const args = buildWhisperArgs("/tmp/audio.mp3", "zh");
+    const idx = args.indexOf("--initial_prompt");
+    expect(idx).toBeGreaterThan(-1);
+    const prompt = args[idx + 1];
+    expect(prompt).toBeTruthy();
+    expect(prompt).toMatch(/[一-鿿]/);
+  });
+
+  it("omits both drift mitigations when no lang is provided (back-compat)", () => {
+    // Callers that don't pass a lang must see the same argv they
+    // always have, so whisper's auto-detect runs unmodified. A stray
+    // condition_on_previous_text=False on the no-lang path would
+    // change behaviour for legitimately mixed-language clips that this
+    // PR isn't trying to address.
+    const args = buildWhisperArgs("/tmp/audio.mp3");
+    expect(args).not.toContain("--condition_on_previous_text");
+    expect(args).not.toContain("--initial_prompt");
+  });
+
+  it("omits --initial_prompt for a lang with no anchor (falls through to flag-only pinning)", () => {
+    // Strictly additive: an ISO 639-1 code we don't have an anchor for
+    // (Welsh, etc.) still gets `--language cy` and the
+    // condition_on_previous_text guard, but no prompt — sending a
+    // wrong-language anchor would actively reintroduce the drift.
+    const args = buildWhisperArgs("/tmp/audio.mp3", "cy");
+    expect(args).toContain("--language");
+    expect(args.indexOf("--condition_on_previous_text")).toBeGreaterThan(-1);
+    expect(args).not.toContain("--initial_prompt");
+  });
 });
 
 describe("parseWhisperJson", () => {

--- a/src/lib/groq-transcribe.ts
+++ b/src/lib/groq-transcribe.ts
@@ -7,6 +7,7 @@ import {
 } from "./audio-compress.js";
 import type { AudioCompressKind } from "./audio-compress.js";
 import type { TranscriptSegment } from "./captions.js";
+import { getLanguageAnchorPrompt } from "./language-prompt.js";
 
 // Subset of Groq's `verbose_json` response we consume. Groq's full shape
 // includes word-level timestamps and per-segment confidence; ignoring them
@@ -113,7 +114,22 @@ export async function transcribeViaGroq(
       );
       body.append("model", model);
       body.append("response_format", "verbose_json");
-      if (lang) body.append("language", lang);
+      if (lang) {
+        body.append("language", lang);
+        // Native-language anchor biases the model toward the target
+        // language even on non-speech audio (silence/music/B-roll
+        // between sentences) where `language` alone isn't enough.
+        // Without this, whisper-large-v3-turbo on Groq hallucinates
+        // English (and even other languages — French "même" was
+        // observed) during low-speech segments and propagates the
+        // drift across subsequent chunks. Captured on video
+        // hrREdNm7vB4 where ~46% of a Chinese audio's segments came
+        // back as nonsense non-Chinese despite `language=zh`. Groq's
+        // hosted Whisper does not expose `condition_on_previous_text`,
+        // so `prompt` is the only available lever for this drift.
+        const anchor = getLanguageAnchorPrompt(lang);
+        if (anchor) body.append("prompt", anchor);
+      }
       return body;
     };
 

--- a/src/lib/language-detect.ts
+++ b/src/lib/language-detect.ts
@@ -9,7 +9,11 @@ const MIN_TEXT_DETECTION_LENGTH = 30;
 // YouTube caption tracks use). Only languages with concrete 639-1 mappings —
 // unlisted 639-3 codes pass through unchanged so the caller can log and
 // fall through to the ultimate fallback rather than silently lying.
-const ISO_639_3_TO_1: Record<string, string> = {
+//
+// Exported as a const for cross-module parity tests (every 639-1 value
+// here must have a matching anchor in language-prompt.ts). Not intended
+// for runtime mutation.
+export const ISO_639_3_TO_1: Record<string, string> = {
   eng: "en",
   cmn: "zh",
   fra: "fr",

--- a/src/lib/language-prompt.ts
+++ b/src/lib/language-prompt.ts
@@ -13,11 +13,17 @@
 // the model's output distribution every chunk, not just the first.
 //
 // Each value is content-neutral ("the following is a sentence in
-// <language>") — long enough to give franc/whisper a strong language
+// <language>") — long enough to give whisper a strong language
 // fingerprint, short enough to stay well under Whisper's 224-token
 // prompt cap. Only ISO 639-1 codes that detectLanguage() can return are
 // listed; unknown codes get null and the caller falls back to
 // language-only flag pinning (the prior behavior).
+//
+// Aside on regurgitation: faster-whisper occasionally echoes the
+// initial_prompt into the first segment when audio opens with silence.
+// If a transcript ever surfaces a leading "The following is a sentence
+// in X" segment, that's the source — known tradeoff vs. the ~46%-
+// hallucination bug this fixes.
 const LANGUAGE_ANCHOR_PROMPTS: Record<string, string> = {
   en: "The following is a sentence in English.",
   zh: "以下是普通话的句子。",
@@ -50,16 +56,34 @@ const LANGUAGE_ANCHOR_PROMPTS: Record<string, string> = {
 };
 
 /**
- * Look up the language-anchor prompt for a given ISO 639-1 code.
+ * Look up the language-anchor prompt for a given language code.
  * Returns null when no anchor is defined for that language so callers
  * can branch on "no anchor available" without conflating it with empty
- * string. Case-insensitive on input.
+ * string.
+ *
+ * Accepts ISO 639-1 (`zh`), BCP-47 with region/script (`zh-Hans`,
+ * `en-US`), and ISO 639-3 (only the 2-letter primary survives — 3-letter
+ * codes outside the lookup return null). The frontend's `primarySubtag`
+ * already normalizes before calling /transcribe, but the VPS schema
+ * accepts BCP-47 directly, so doing the normalization here too means
+ * `lang=zh-Hans` (a real Chinese variant) hits the zh anchor instead of
+ * silently falling through to flag-only pinning and reintroducing the
+ * drift bug for the dominant Chinese case.
  *
  * Used by both the Groq transcription path (`prompt` form field) and
  * the local Whisper fallback (`--initial_prompt` flag).
  */
 export function getLanguageAnchorPrompt(lang: string | null | undefined): string | null {
   if (!lang) return null;
-  const normalized = lang.toLowerCase().trim();
-  return LANGUAGE_ANCHOR_PROMPTS[normalized] ?? null;
+  const lower = lang.toLowerCase().trim();
+  if (!lower) return null;
+  // Direct hit for the common case (`zh`, `en`, etc.).
+  if (LANGUAGE_ANCHOR_PROMPTS[lower]) return LANGUAGE_ANCHOR_PROMPTS[lower];
+  // BCP-47 / 3-letter: extract the primary 2-letter subtag and retry.
+  // Mirrors normalizeLanguageCode in language-detect.ts — duplicated
+  // here to keep this module independent of franc-loading transitive
+  // imports, but the regex is intentionally identical.
+  const match = lower.match(/^([a-z]{2})(?:-.+)?$/);
+  if (match) return LANGUAGE_ANCHOR_PROMPTS[match[1]] ?? null;
+  return null;
 }

--- a/src/lib/language-prompt.ts
+++ b/src/lib/language-prompt.ts
@@ -1,0 +1,65 @@
+// Short native-language sentences passed as Whisper's `initial_prompt` /
+// Groq's `prompt`. Anchors the model to the target language even on
+// non-speech audio (silence, music, B-roll between speech) so it doesn't
+// drift into hallucinated English/French/etc — the bug captured at
+// video hrREdNm7vB4 where ~46% of segments came back as nonsense
+// English despite `--language zh` being pinned.
+//
+// Why a prompt and not just `--language`: the `--language` flag tells
+// Whisper which language to *transcribe to*, but with the default
+// `condition_on_previous_text=True` Whisper still propagates a
+// hallucinated English token across subsequent chunks until strong
+// native audio resets it. A native-language anchor in the prompt biases
+// the model's output distribution every chunk, not just the first.
+//
+// Each value is content-neutral ("the following is a sentence in
+// <language>") — long enough to give franc/whisper a strong language
+// fingerprint, short enough to stay well under Whisper's 224-token
+// prompt cap. Only ISO 639-1 codes that detectLanguage() can return are
+// listed; unknown codes get null and the caller falls back to
+// language-only flag pinning (the prior behavior).
+const LANGUAGE_ANCHOR_PROMPTS: Record<string, string> = {
+  en: "The following is a sentence in English.",
+  zh: "以下是普通话的句子。",
+  fr: "Ce qui suit est une phrase en français.",
+  es: "Lo siguiente es una oración en español.",
+  ja: "以下は日本語の文です。",
+  ko: "다음은 한국어 문장입니다.",
+  de: "Das Folgende ist ein Satz auf Deutsch.",
+  pt: "A seguir está uma frase em português.",
+  ru: "Это предложение на русском языке.",
+  it: "La seguente è una frase in italiano.",
+  ar: "ما يلي هو جملة باللغة العربية.",
+  hi: "यह हिंदी में एक वाक्य है।",
+  nl: "Het volgende is een zin in het Nederlands.",
+  tr: "Aşağıdaki Türkçe bir cümledir.",
+  vi: "Sau đây là một câu tiếng Việt.",
+  id: "Berikut adalah kalimat dalam bahasa Indonesia.",
+  th: "ต่อไปนี้เป็นประโยคภาษาไทย",
+  pl: "Poniżej znajduje się zdanie po polsku.",
+  uk: "Це речення українською мовою.",
+  sv: "Följande är en mening på svenska.",
+  da: "Følgende er en sætning på dansk.",
+  no: "Følgende er en setning på norsk.",
+  fi: "Seuraava on lause suomeksi.",
+  cs: "Následuje věta v češtině.",
+  el: "Το ακόλουθο είναι μια πρόταση στα ελληνικά.",
+  he: "להלן משפט בעברית.",
+  ro: "Următoarea este o propoziție în limba română.",
+  hu: "A következő egy mondat magyarul.",
+};
+
+/**
+ * Look up the language-anchor prompt for a given ISO 639-1 code.
+ * Returns null when no anchor is defined for that language so callers
+ * can branch on "no anchor available" without conflating it with empty
+ * string. Case-insensitive on input.
+ *
+ * Used by both the Groq transcription path (`prompt` form field) and
+ * the local Whisper fallback (`--initial_prompt` flag).
+ */
+export function getLanguageAnchorPrompt(lang: string | null | undefined): string | null {
+  if (!lang) return null;
+  const normalized = lang.toLowerCase().trim();
+  return LANGUAGE_ANCHOR_PROMPTS[normalized] ?? null;
+}

--- a/src/lib/whisper.ts
+++ b/src/lib/whisper.ts
@@ -3,6 +3,7 @@ import { readFile, unlink } from "fs/promises";
 import { tmpdir } from "os";
 import { join, basename } from "path";
 import type { TranscriptSegment } from "./captions.js";
+import { getLanguageAnchorPrompt } from "./language-prompt.js";
 
 export function buildWhisperArgs(audioPath: string, lang?: string): string[] {
   const args = [
@@ -34,6 +35,26 @@ export function buildWhisperArgs(audioPath: string, lang?: string): string[] {
   // still the safer default when confidence is low.
   if (lang) {
     args.push("--language", lang);
+    // Disable previous-chunk conditioning when a language is pinned.
+    // Default is True, which carries forward whisper's last-window output
+    // as context for the next window. Once whisper hallucinates a token
+    // in the wrong language during a non-speech segment (silence between
+    // sentences, background music, B-roll), that hallucination
+    // propagates through subsequent chunks until strong native audio
+    // resets it — captured on video hrREdNm7vB4 where ~46% of a Chinese
+    // audio's segments came back as nonsense English with `--language
+    // zh` pinned. Disabling the conditioning keeps each window
+    // independent so a single bad chunk can't cascade.
+    args.push("--condition_on_previous_text", "False");
+    // Native-language anchor sentence biases whisper's output
+    // distribution toward the target language for low-confidence
+    // segments where `--language` alone isn't enough. Only set when we
+    // have an anchor for this code; otherwise fall through to flag-only
+    // pinning (the prior behavior — strictly additive guard).
+    const anchor = getLanguageAnchorPrompt(lang);
+    if (anchor) {
+      args.push("--initial_prompt", anchor);
+    }
   }
   return args;
 }


### PR DESCRIPTION
## Summary

- Whisper's `language` flag tells the model what to transcribe *to*, but doesn't stop it from hallucinating in another language during non-speech audio (silence/music/B-roll). Default `condition_on_previous_text=True` then propagates the drift across subsequent chunks until strong native audio resets it.
- Captured on https://www.youtube.com/watch?v=hrREdNm7vB4: Chinese audio, ~46% of returned segments were nonsense English (and one French "même") despite `language=zh` already being pinned through Groq.
- Fix: add a short native-language anchor sentence for 28 ISO 639-1 codes; send it as Groq's `prompt` form field (production path) and as `--initial_prompt` + `--condition_on_previous_text False` for the local-Whisper fallback. Strictly additive — no `lang` or unknown `lang` produces the prior argv / form data unchanged.

## Test plan

- [x] `npm test` — 272 pass (was 257; +15 new across 3 files)
- [x] `npx tsc --noEmit` — clean
- [ ] Post-deploy e2e against https://www.youtubeai.chat for video `hrREdNm7vB4` after invalidating the cached transcript row — verify the new run produces ≥95% Chinese-containing segments (the original was 54%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)