### PR TITLE
fix(language-detect): swap franc for eld + CJK script fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All data endpoints require `Authorization: Bearer <VPS_API_KEY>`.
 
 ## Tech
 
-Node.js 22, Hono, Python (faster-whisper), yt-dlp, ffmpeg, `franc` for text-based language detection. Runs in Docker.
+Node.js 22, Hono, Python (faster-whisper), yt-dlp, ffmpeg, `eld` for text-based language detection (with a CJK Unicode-script fallback for short titles where eld is unreliable). Runs in Docker.
 
 ## Architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,31 @@
         "vitest": "^4.1.5"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hono/node-server": "^2.0.0",
-        "franc": "^6.2.0",
+        "eld": "^2.0.3",
         "hono": "^4.12.15",
         "youtube-transcript-plus": "^2.0.0",
         "zod": "^4.3.6"
@@ -19,31 +19,6 @@
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -998,16 +973,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/collapse-white-space": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
-      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1023,6 +988,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/eld": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eld/-/eld-2.0.3.tgz",
+      "integrity": "sha512-KiwFrycPPJ2XgKb7MGsJ3m3grUFXq6+55R8ZuS9fj+Qv0WRFgeEBhmorHO/YwHV9VqhdJURKFGJ+CY24sEikOw==",
+      "license": "Apache-2.0",
+      "funding": {
+        "url": "https://linktr.ee/nitotm"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1110,19 +1084,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/franc": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/franc/-/franc-6.2.0.tgz",
-      "integrity": "sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==",
-      "license": "MIT",
-      "dependencies": {
-        "trigram-utils": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/fsevents": {
@@ -1434,16 +1395,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/n-gram": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
-      "integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1648,20 +1599,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/trigram-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
-      "integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "collapse-white-space": "^2.0.0",
-        "n-gram": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.0",
-    "franc": "^6.2.0",
+    "eld": "^2.0.3",
     "hono": "^4.12.15",
     "youtube-transcript-plus": "^2.0.0",
     "zod": "^4.3.6"

--- a/src/lib/__tests__/language-detect.test.ts
+++ b/src/lib/__tests__/language-detect.test.ts
@@ -139,11 +139,13 @@ describe("detectLanguage", () => {
     // for non-CJK short text — an unreliable Latin-script guess beats
     // null because the language hint then propagates to whisper's
     // prompt anchor, biasing output even on uncertain detection.
-    // "Gracias" is unreliable but eld returns "es"; "Hi" is too short
-    // for any signal and may return "" → null. Either is acceptable;
-    // the contract is "string-or-null, never an unrelated guess".
-    const gracias = detectLanguage({ ...base, title: "Gracias", description: "" });
-    expect(gracias === "es" || gracias === null).toBe(true);
+    // Pin the deterministic case: eld v2/extrasmall on "Gracias"
+    // returns "es" (unreliable). A future eld bump that drops short-
+    // Latin guesses entirely IS the regression we want surfaced —
+    // a `expect(... || null)` disjunction would silently let it slide.
+    expect(detectLanguage({ ...base, title: "Gracias", description: "" })).toBe(
+      "es"
+    );
   });
 
   it("CJK script fallback overrides eld for short mixed-script titles", () => {
@@ -195,6 +197,48 @@ describe("detectLanguage", () => {
         description: "",
       })
     ).toBe("ko");
+  });
+
+  it("script fallback handles mixed Hangul + Latin (Korean analog of 极海Channel)", () => {
+    // Same mixed-script class as the captured "极海Channel" failure
+    // — short text where eld might pick the Latin word and miss the
+    // Hangul evidence.
+    expect(
+      detectLanguage({ ...base, title: "K-Pop 프로그래밍", description: "" })
+    ).toBe("ko");
+    // Japanese mixed-script with kana (the Japanese-disambiguator)
+    // resolves to ja even when adjacent to Latin words. Pure-kanji
+    // text without kana would resolve to zh — that's a documented
+    // limitation of the script heuristic, not a regression.
+    expect(
+      detectLanguage({ ...base, title: "Gaming プログラミング講座", description: "" })
+    ).toBe("ja");
+  });
+
+  it("script fallback fires on description-only signal (no title)", () => {
+    // The detection runs on `title + description` so a video with no
+    // title and a Chinese description should still resolve to zh. Pins
+    // the concatenation behavior; without this, a future refactor
+    // could accidentally restrict detection to title only.
+    expect(
+      detectLanguage({
+        ...base,
+        title: "",
+        description: "这是一段中文描述",
+      })
+    ).toBe("zh");
+  });
+
+  it.each([
+    ["whitespace only", "   \t\n  "],
+    ["digits only", "12345"],
+    ["punctuation only", "!!!???..."],
+    ["emoji only", "🔥🔥🔥"],
+  ])("returns null for %s (no detectable language signal)", (_label, title) => {
+    // None of these contain Han / kana / Hangul, and eld returns ""
+    // (no detection) for content-free input. Pin null rather than
+    // letting eld's behavior on novel inputs drift through.
+    expect(detectLanguage({ ...base, title, description: "" })).toBeNull();
   });
 
   it("falls through to text detection when the sole subtitle key is unnormalizable", () => {

--- a/src/lib/__tests__/language-detect.test.ts
+++ b/src/lib/__tests__/language-detect.test.ts
@@ -125,26 +125,76 @@ describe("detectLanguage", () => {
     expect(result).toBe("zh");
   });
 
-  it("falls back to 'en' when text is too short for confident detection", () => {
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    const result = detectLanguage({ ...base, title: "Hi", description: "" });
-    expect(result).toBe("en");
+  it("returns null when text is empty (no signal at all)", () => {
+    // The function honestly reports "no signal" instead of guessing "en".
+    // The route layer is responsible for mapping null → "en" with a
+    // structured warn log; testing the route fallback lives in
+    // routes/__tests__/metadata.test.ts so the wire-contract back-compat
+    // is pinned independently of the detection internals.
+    expect(detectLanguage({ ...base, title: "", description: "" })).toBeNull();
   });
 
-  it("logs LANGUAGE_DETECT_FALLBACK with context when every signal fails", async () => {
-    // A silent "en" here defeats the whole point of the PR — a rising
-    // miss rate should be alertable. Lock the errorId + context shape
-    // so a future refactor can't drop the log.
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    detectLanguage({ ...base, title: "Hi", description: "" });
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("fallback to en"),
-      expect.objectContaining({
-        errorId: "LANGUAGE_DETECT_FALLBACK",
-        hasLanguageField: false,
-        subtitleKeyCount: 0,
+  it("returns eld's best guess for short Latin titles even when unreliable", () => {
+    // Per spec: even when eld.isReliable() is false, use result.language
+    // for non-CJK short text — an unreliable Latin-script guess beats
+    // null because the language hint then propagates to whisper's
+    // prompt anchor, biasing output even on uncertain detection.
+    // "Gracias" is unreliable but eld returns "es"; "Hi" is too short
+    // for any signal and may return "" → null. Either is acceptable;
+    // the contract is "string-or-null, never an unrelated guess".
+    const gracias = detectLanguage({ ...base, title: "Gracias", description: "" });
+    expect(gracias === "es" || gracias === null).toBe(true);
+  });
+
+  it("CJK script fallback overrides eld for short mixed-script titles", () => {
+    // Captured failure: "极海Channel" (Chinese channel name + Latin
+    // word) is detected by eld as French with isReliable=true. A
+    // single Han char is unambiguous Chinese signal — script range
+    // check pre-empts eld for any text containing CJK Unified
+    // Ideographs / Hiragana / Katakana / Hangul. Same path catches
+    // the bug video hrREdNm7vB4 (~18 Chinese chars, below franc's
+    // prior 30-char threshold).
+    expect(
+      detectLanguage({ ...base, title: "极海Channel", description: "" })
+    ).toBe("zh");
+    expect(
+      detectLanguage({
+        ...base,
+        title: "初级开发别跳槽！最新大裁员4个主要原因！",
+        description: "",
       })
-    );
+    ).toBe("zh");
+  });
+
+  it("script fallback distinguishes Japanese (kana) from Chinese (Han only)", () => {
+    // Japanese uses both kana and kanji. Pure-Han text → zh; any kana
+    // present → ja. Order in detectByScript matters: kana check before
+    // Han check so a Japanese title with both scripts isn't
+    // misclassified as Chinese.
+    expect(
+      detectLanguage({
+        ...base,
+        title: "プログラミングを学ぶ",
+        description: "",
+      })
+    ).toBe("ja");
+    expect(
+      detectLanguage({
+        ...base,
+        title: "今日は日本語の話",
+        description: "",
+      })
+    ).toBe("ja");
+  });
+
+  it("script fallback returns ko for Hangul", () => {
+    expect(
+      detectLanguage({
+        ...base,
+        title: "프로그래밍을 배우자",
+        description: "",
+      })
+    ).toBe("ko");
   });
 
   it("falls through to text detection when the sole subtitle key is unnormalizable", () => {
@@ -165,7 +215,6 @@ describe("detectLanguage", () => {
     // regardless of the source language. Trusting this field would let a
     // captioned French video get labelled English (alphabetically first)
     // or arbitrary.
-    vi.spyOn(console, "warn").mockImplementation(() => {});
     const result = detectLanguage({
       ...base,
       automatic_captions: {
@@ -174,7 +223,10 @@ describe("detectLanguage", () => {
         fr: [{ url: "x", ext: "vtt" }],
       },
     });
-    expect(result).toBe("en"); // ultimate fallback (no other signal)
+    // Returns null — automatic_captions is not used as signal, and
+    // there's no title/description to detect from. The route layer
+    // maps null → "en" with a structured warn for ops visibility.
+    expect(result).toBeNull();
   });
 });
 

--- a/src/lib/language-detect.ts
+++ b/src/lib/language-detect.ts
@@ -1,18 +1,11 @@
-import { franc } from "franc";
+import { eld } from "eld/extrasmall";
 
-// Minimum character count before we trust franc's output. Below this, franc's
-// trigram model produces noisy results (short text often mis-detects as an
-// exotic language). 30 chars is the library's own documented threshold.
-const MIN_TEXT_DETECTION_LENGTH = 30;
-
-// Codes we map from franc's ISO 639-3 output to ISO 639-1 (what whisper and
-// YouTube caption tracks use). Only languages with concrete 639-1 mappings —
-// unlisted 639-3 codes pass through unchanged so the caller can log and
-// fall through to the ultimate fallback rather than silently lying.
-//
-// Exported as a const for cross-module parity tests (every 639-1 value
-// here must have a matching anchor in language-prompt.ts). Not intended
-// for runtime mutation.
+// Codes the prior franc-based implementation could return as ISO 639-3.
+// Kept as a const for cross-module parity tests (every 639-1 value here
+// must have a matching anchor in language-prompt.ts) and for
+// `normalizeLanguageCode` to translate any 3-letter codes a caller
+// happens to pass through. Not used by the new eld-based detection
+// path — eld returns ISO 639-1 directly.
 export const ISO_639_3_TO_1: Record<string, string> = {
   eng: "en",
   cmn: "zh",
@@ -68,11 +61,12 @@ export interface YtdlpMetadata {
   >;
 }
 
-// yt-dlp / franc sentinels that mean "no linguistic content" or "ambiguous" —
-// forwarding any of these to whisper as `--language zxx` produces a cryptic
-// CLI error. Treat as "no signal" and let callers fall through.
+// yt-dlp / detector sentinels that mean "no linguistic content" or
+// "ambiguous" — forwarding any of these to whisper as `--language zxx`
+// produces a cryptic CLI error. Treat as "no signal" and let callers
+// fall through.
 const LANGUAGE_SENTINELS: ReadonlySet<string> = new Set([
-  "und", // undetermined — franc's "couldn't detect" output
+  "und", // undetermined
   "zxx", // no linguistic content — yt-dlp uses this for music-only tracks
   "mul", // multiple languages
   "mis", // uncoded languages
@@ -105,21 +99,80 @@ export function normalizeLanguageCode(code: string | null | undefined): string |
   return ISO_639_3_TO_1[primary] ?? null;
 }
 
+// Hiragana (぀–ゟ) and Katakana (゠–ヿ) are
+// Japanese-only — not present in Chinese or Korean. Match before Han
+// because Japanese also uses Han chars (kanji), but the presence of
+// even one kana char is unambiguous evidence of Japanese.
+const JAPANESE_KANA_RE = /[぀-ゟ゠-ヿ]/;
+// Hangul syllables (가–힯) and Jamo (ᄀ–ᇿ) are
+// Korean-only.
+const KOREAN_HANGUL_RE = /[가-힯ᄀ-ᇿ]/;
+// CJK Unified Ideographs (一–鿿) — used by Chinese (and
+// Japanese kanji, but kana check above pre-empts that case). Title-
+// only check on the assumption that any presence of Han chars in a
+// short YouTube title strongly suggests Chinese audience targeting,
+// even when mixed with Latin (e.g. "极海Channel" — eld misclassifies
+// this as French; the script check correctly returns zh).
+const HAN_RE = /[一-鿿]/;
+
+/**
+ * Script-based language detection. Returns null when no CJK script
+ * is present so the caller can fall through to eld for Latin / other
+ * scripts. Order matters: kana → ja before han → zh because Japanese
+ * uses both kana and kanji and we want the more specific signal to win.
+ */
+function detectByScript(text: string): string | null {
+  if (JAPANESE_KANA_RE.test(text)) return "ja";
+  if (KOREAN_HANGUL_RE.test(text)) return "ko";
+  if (HAN_RE.test(text)) return "zh";
+  return null;
+}
+
+/**
+ * Detect language from text using eld with a CJK script-range fallback
+ * for short titles. Returns ISO 639-1 or null. Trusts eld even when
+ * `isReliable()` returns false — for short Latin titles like "Hello"
+ * or "Gracias" the unreliable detection is still better than a "no
+ * signal" null that forces callers into a bare auto-detect on the
+ * audio path. eld's empty-string return (no detection at all) maps to
+ * null so the caller can decide.
+ *
+ * Script detection runs *before* eld for CJK text because eld gets
+ * confused by short mixed-script titles — "极海Channel" is detected as
+ * French with isReliable=true, but a single Han char is unambiguous
+ * Chinese signal. Matches the bug class captured on hrREdNm7vB4 where
+ * the title (~18 Chinese chars) was below franc's 30-char threshold
+ * and fell through to the "en" fallback.
+ */
+function detectFromText(text: string): string | null {
+  if (!text.trim()) return null;
+  const fromScript = detectByScript(text);
+  if (fromScript) return fromScript;
+  const result = eld.detect(text);
+  // Per spec: trust eld.language even when isReliable() is false —
+  // unreliable Latin-script detection beats null for our use case
+  // because the language hint then propagates to whisper's prompt
+  // anchor, which biases output even on uncertain detection.
+  const normalized = normalizeLanguageCode(result.language);
+  return normalized;
+}
+
 /**
  * Derive the video's language from yt-dlp metadata. Priority order:
  *   1. `language` field (uploader-specified, authoritative).
  *   2. Sole manually-uploaded subtitle track (2+ tracks is ambiguous — a
  *      French-source uploader often ships fr + en, and picking one
  *      arbitrarily reintroduces the tracks[0] bug class).
- *   3. Text detection on description + title via franc (heuristic fallback).
- *   4. `"en"` ultimate fallback, with a warn log so a high miss rate is
- *      observable in production (a rising rate is a detection-quality
- *      regression or a corpus of metadata-sparse videos we should fix).
+ *   3. Text detection (CJK script range → eld) on title + description.
+ *   4. Returns null when every signal failed — callers should log and
+ *      decide. Ultimate-fallback "en" lives in the route layer, not
+ *      here, so the function honestly reports "no signal" instead of
+ *      lying with a guess.
  *
- * `automatic_captions` is NOT used as a signal — YouTube populates it with
- * many auto-translations regardless of source language.
+ * `automatic_captions` is NOT used as a signal — YouTube populates it
+ * with many auto-translations regardless of source language.
  */
-export function detectLanguage(metadata: YtdlpMetadata): string {
+export function detectLanguage(metadata: YtdlpMetadata): string | null {
   const fromLanguage = normalizeLanguageCode(metadata.language);
   if (fromLanguage) return fromLanguage;
 
@@ -132,24 +185,7 @@ export function detectLanguage(metadata: YtdlpMetadata): string {
   }
 
   const text = `${metadata.title ?? ""} ${metadata.description ?? ""}`.trim();
-  let francResult: string | null = null;
-  if (text.length >= MIN_TEXT_DETECTION_LENGTH) {
-    francResult = franc(text);
-    const normalized = normalizeLanguageCode(francResult);
-    if (normalized) return normalized;
-  }
-
-  // Everything failed. Log the fallback so a rising miss rate is alertable —
-  // a silent "en" here defeats the PR's purpose of pinning the right
-  // language to whisper.
-  console.warn("[language-detect] fallback to en (no usable signal)", {
-    errorId: "LANGUAGE_DETECT_FALLBACK",
-    hasLanguageField: Boolean(metadata.language),
-    subtitleKeyCount: subtitleKeys.length,
-    textLength: text.length,
-    francResult,
-  });
-  return "en";
+  return detectFromText(text);
 }
 
 /**

--- a/src/lib/language-detect.ts
+++ b/src/lib/language-detect.ts
@@ -64,7 +64,11 @@ export interface YtdlpMetadata {
 // yt-dlp / detector sentinels that mean "no linguistic content" or
 // "ambiguous" — forwarding any of these to whisper as `--language zxx`
 // produces a cryptic CLI error. Treat as "no signal" and let callers
-// fall through.
+// fall through. eld reports "no detection" by returning the empty
+// string, not a sentinel — so the und/mul/mis entries are
+// defensive-only for callers passing these tags through
+// `normalizeLanguageCode` (yt-dlp can emit `language: "zxx"` for
+// music-only tracks).
 const LANGUAGE_SENTINELS: ReadonlySet<string> = new Set([
   "und", // undetermined
   "zxx", // no linguistic content — yt-dlp uses this for music-only tracks
@@ -108,11 +112,14 @@ const JAPANESE_KANA_RE = /[぀-ゟ゠-ヿ]/;
 // Korean-only.
 const KOREAN_HANGUL_RE = /[가-힯ᄀ-ᇿ]/;
 // CJK Unified Ideographs (一–鿿) — used by Chinese (and
-// Japanese kanji, but kana check above pre-empts that case). Title-
-// only check on the assumption that any presence of Han chars in a
-// short YouTube title strongly suggests Chinese audience targeting,
-// even when mixed with Latin (e.g. "极海Channel" — eld misclassifies
-// this as French; the script check correctly returns zh).
+// Japanese kanji, but kana check above pre-empts that case). Applied
+// to the title + description concatenation; even one Han char
+// outweighs an ambiguous Latin / mixed-script eld guess (e.g.
+// "极海Channel" — eld returns French with isReliable=true, but a
+// single Han char is unambiguous Chinese signal). Doesn't cover CJK
+// Extension A (U+3400-U+4DBF) or B+ (U+20000+) — vanishingly rare for
+// YouTube titles and eld picks up the long tail; revisit if
+// LANGUAGE_DETECT_FALLBACK warns surface those characters.
 const HAN_RE = /[一-鿿]/;
 
 /**

--- a/src/lib/language-prompt.ts
+++ b/src/lib/language-prompt.ts
@@ -95,8 +95,9 @@ export function getLanguageAnchorPrompt(lang: string | null | undefined): string
   if (LANGUAGE_ANCHOR_PROMPTS[lower]) return LANGUAGE_ANCHOR_PROMPTS[lower];
   // BCP-47 / 3-letter: extract the primary 2-letter subtag and retry.
   // Mirrors normalizeLanguageCode in language-detect.ts — duplicated
-  // here to keep this module independent of franc-loading transitive
-  // imports, but the regex is intentionally identical.
+  // here to keep this module independent of language-detect's
+  // transitive imports (eld bundle), but the regex is intentionally
+  // identical.
   const match = lower.match(/^([a-z]{2})(?:-.+)?$/);
   if (match) return LANGUAGE_ANCHOR_PROMPTS[match[1]] ?? null;
   return null;

--- a/src/lib/ytdlp-metadata.ts
+++ b/src/lib/ytdlp-metadata.ts
@@ -4,8 +4,8 @@ import type { YtdlpMetadata } from "./language-detect.js";
 
 // Descriptions are unbounded user content. Truncate before returning so we
 // don't bloat JSON responses or log lines. 2000 chars is more than enough
-// for language detection (franc's trigram model saturates around ~200
-// chars) and fits comfortably in a debug log.
+// for eld's n-gram language model (saturates well below this cap) and
+// fits comfortably in a debug log.
 const DESCRIPTION_CHAR_CAP = 2000;
 
 // Metadata extraction is fast compared to audio download (no byte

--- a/src/routes/__tests__/metadata.test.ts
+++ b/src/routes/__tests__/metadata.test.ts
@@ -65,6 +65,7 @@ describe("POST /metadata", () => {
   });
 
   it("returns 200 with language, title, description, duration, availableCaptions on happy path", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(ytdlpMetadataLib, "fetchYtdlpMetadata").mockResolvedValue({
       title: "Comment apprendre",
       description: "Une vidéo en français",
@@ -83,6 +84,14 @@ describe("POST /metadata", () => {
     expect(body.description).toBe("Une vidéo en français");
     expect(body.duration).toBe(893);
     expect(body.availableCaptions).toEqual(expect.arrayContaining(["fr", "en"]));
+    // The fallback warn must NOT fire on the happy path — a refactor
+    // that always logs (e.g. moves the warn outside the null branch)
+    // would silently flood ops dashboards with false-positive miss
+    // signals and make the dashboards useless for real regressions.
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("LANGUAGE_DETECT_FALLBACK"),
+      expect.anything()
+    );
   });
 
   it("forwards duration=null (live streams) without coercing to 0", async () => {

--- a/src/routes/__tests__/metadata.test.ts
+++ b/src/routes/__tests__/metadata.test.ts
@@ -105,6 +105,38 @@ describe("POST /metadata", () => {
     expect(body.duration).toBeNull();
   });
 
+  it("maps detectLanguage null → 'en' with structured LANGUAGE_DETECT_FALLBACK warn", async () => {
+    // Wire-contract back-compat: the frontend's VPS metadata schema
+    // rejects `language: null`, so the route must emit a string. The
+    // fallback log lets ops track miss rate without breaking
+    // deserialization. Capture the structured warn so a future
+    // refactor that drops the log fails this test instead of silently
+    // hiding a rising fallback rate.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(ytdlpMetadataLib, "fetchYtdlpMetadata").mockResolvedValue({
+      title: "", // no title and no description = no detection signal at all
+      description: "",
+      language: null,
+      duration: null,
+      subtitles: {},
+      automatic_captions: {},
+    });
+    const res = await post({
+      youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.language).toBe("en");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("LANGUAGE_DETECT_FALLBACK"),
+      expect.objectContaining({
+        errorId: "LANGUAGE_DETECT_FALLBACK",
+        hasLanguageField: false,
+        subtitleKeyCount: 0,
+      })
+    );
+  });
+
   it("returns 500 with a generic message when yt-dlp throws", async () => {
     // Internal stderr (paths, binary names, extractor internals) must not
     // leak to the client — same contract as /captions and /transcribe.

--- a/src/routes/metadata.ts
+++ b/src/routes/metadata.ts
@@ -43,7 +43,28 @@ metadata.post("/", async (c) => {
   try {
     console.log(`Fetching metadata for video ${videoId}`);
     const ytdlpMeta = await fetchYtdlpMetadata(youtube_url);
-    const language = detectLanguage(ytdlpMeta);
+    const detected = detectLanguage(ytdlpMeta);
+    // The wire contract requires `language` to be a string (frontend
+    // schema rejects null). Map null → "en" at the route boundary so
+    // detectLanguage can honestly report "no signal" internally
+    // without breaking the API. The structured warn lets ops track
+    // fallback rate — a rising rate is a detection-quality regression
+    // or a corpus of metadata-sparse videos worth investigating.
+    let language: string;
+    if (detected) {
+      language = detected;
+    } else {
+      console.warn(`[metadata] LANGUAGE_DETECT_FALLBACK for video ${videoId}`, {
+        errorId: "LANGUAGE_DETECT_FALLBACK",
+        videoId,
+        hasLanguageField: Boolean(ytdlpMeta.language),
+        subtitleKeyCount: Object.keys(ytdlpMeta.subtitles).length,
+        textLength:
+          (ytdlpMeta.title?.length ?? 0) +
+          (ytdlpMeta.description?.length ?? 0),
+      });
+      language = "en";
+    }
     const availableCaptions = extractAvailableCaptions(ytdlpMeta);
 
     return c.json({


### PR DESCRIPTION
## Summary

Verified failure: video `hrREdNm7vB4`'s title (~18 Chinese chars) is below franc's 30-char minimum, so `detectLanguage` fell through to its `"en"` fallback. Frontend then sent `lang=en` to `/transcribe` and `whisper-large-v3` **translated** the Chinese audio to English instead of transcribing it. Coherent, accurate, but not what the user asked for.

The deeper issue: franc's trigram model is unreliable for any short text, but YouTube titles are routinely short. Per Daisy's research note, `eld` is more accurate on short text, returns ISO 639-1 directly (no 3-letter mapping table needed), and exposes an `isReliable()` signal.

## Detection priority (changed)

1. Uploader-set `language` field (unchanged)
2. Sole manual subtitle track (unchanged)
3. **CJK script range (NEW)**: Han → zh, Hiragana/Katakana → ja, Hangul → ko. Pre-empts eld because eld misclassifies short mixed-script titles like `极海Channel` as French with `isReliable=true` — a single Han char is unambiguous Chinese signal.
4. **eld on title + description (NEW; replaces franc)**. Trusts eld's `language` even when `isReliable()` is false because for short Latin titles (`"Gracias"`) an unreliable guess beats a `null` that would force whisper into bare auto-detect.
5. **Returns `null` when every signal failed** (was: `"en"` fallback). The route layer maps null → `"en"` with a structured `LANGUAGE_DETECT_FALLBACK` warn so the frontend's wire contract (string) is preserved while ops can track miss rate.

The `MIN_TEXT_DETECTION_LENGTH = 30` gate is removed — eld's short-text accuracy makes it unnecessary, and the CJK script fallback covers the case the gate was protecting against.

## Test plan

- [x] `npm test` — 280 pass (was 276; +4 new for CJK fallback / null contract / route-level fallback log)
- [x] `npx tsc --noEmit` — clean
- [ ] Post-deploy: invalidate `hrREdNm7vB4` cache rows, re-run, verify the transcript comes back as **Chinese** (not the English translation we got after the prior model swap PR landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)